### PR TITLE
feat(analysis): dependency graph + circular import detection

### DIFF
--- a/app/analysis/dependency_graph.py
+++ b/app/analysis/dependency_graph.py
@@ -1,0 +1,478 @@
+"""Dependency graph analysis — module-level import topology with cycle detection.
+
+Parses import statements purely in-process:
+- Python: ``ast.Import`` / ``ast.ImportFrom``
+- JavaScript / TypeScript: ``require(...)`` and ``import ... from ...`` via regex
+
+Public API
+----------
+``DependencyAnalyzer(repo_path)``
+    Main entry point.  Call ``analyze()`` to build the graph.
+
+``DependencyGraph``
+    Result model with:
+    - ``get_imports(module)``     — direct imports of *module*
+    - ``get_importers(module)``   — who imports *module*
+    - ``cycles``                  — list of detected circular import paths
+    - ``coupling_scores``         — {module: 0.0–1.0}
+    - ``orphans``                 — modules with no importers
+    - ``to_mermaid()``            — Mermaid diagram string
+    - ``to_dict()``               — JSON-serialisable dict
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterator
+
+from pydantic import BaseModel, Field
+
+from app.core.logging import get_logger
+
+logger = get_logger("analysis.dependency_graph")
+
+_PY_EXTS  = {".py"}
+_JS_EXTS  = {".js", ".jsx", ".mjs", ".cjs"}
+_TS_EXTS  = {".ts", ".tsx"}
+
+_SKIP_DIRS = {
+    ".git", "__pycache__", ".pytest_cache", ".ruff_cache",
+    "node_modules", ".venv", "venv", ".tox", "dist", "build", ".daedalus",
+}
+
+_MAX_FILES = 500
+
+# JS/TS import patterns
+_JS_IMPORT_RE = re.compile(
+    r"""(?:require\s*\(\s*['"]([^'"]+)['"]\s*\)|"""
+    r"""import\s+.*?from\s+['"]([^'"]+)['"]|"""
+    r"""import\s+['"]([^'"]+)['"])""",
+    re.MULTILINE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+class DependencyGraph(BaseModel):
+    """Module-level directed import graph.
+
+    ``imports``:  module → list[modules it imports]   (out-edges)
+    ``importers``: module → list[modules that import it]  (in-edges)
+    ``cycles``:   list of cycle paths, each path is a list of module names
+    ``coupling_scores``: module → float (0–1, higher = more coupled)
+    ``language``: detected primary language
+    ``files_analysed``: number of files processed
+    ``parse_errors``: files skipped due to errors
+    """
+
+    imports:   dict[str, list[str]] = Field(default_factory=dict)
+    importers: dict[str, list[str]] = Field(default_factory=dict)
+    cycles:    list[list[str]]      = Field(default_factory=list)
+    coupling_scores: dict[str, float] = Field(default_factory=dict)
+    language:  str = "unknown"
+    files_analysed: int = 0
+    parse_errors:   int = 0
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    def get_imports(self, module: str) -> list[str]:
+        """Return modules directly imported by *module*."""
+        return list(self.imports.get(module, []))
+
+    def get_importers(self, module: str) -> list[str]:
+        """Return modules that directly import *module*."""
+        return list(self.importers.get(module, []))
+
+    def all_modules(self) -> set[str]:
+        return set(self.imports.keys()) | set(self.importers.keys())
+
+    def orphans(self) -> list[str]:
+        """Modules that nobody imports (potential dead modules)."""
+        return sorted(m for m in self.all_modules() if not self.importers.get(m))
+
+    def most_coupled(self, n: int = 5) -> list[tuple[str, float]]:
+        """Top-*n* modules by coupling score."""
+        return sorted(self.coupling_scores.items(), key=lambda x: x[1], reverse=True)[:n]
+
+    # ------------------------------------------------------------------
+    # Mermaid generation
+    # ------------------------------------------------------------------
+
+    def to_mermaid(self, highlight_cycles: bool = True) -> str:
+        """Return a Mermaid ``graph TD`` diagram string.
+
+        Cycle edges are rendered in red when *highlight_cycles* is True.
+        """
+        lines = ["graph TD"]
+
+        # Collect cycle edges for highlighting
+        cycle_edges: set[tuple[str, str]] = set()
+        if highlight_cycles:
+            for cycle in self.cycles:
+                for i in range(len(cycle)):
+                    a = cycle[i]
+                    b = cycle[(i + 1) % len(cycle)]
+                    cycle_edges.add((a, b))
+
+        # Sanitise node IDs (Mermaid dislikes dots and slashes)
+        def _id(name: str) -> str:
+            return re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+        rendered_nodes: set[str] = set()
+        for mod, deps in self.imports.items():
+            mid = _id(mod)
+            if mid not in rendered_nodes:
+                lines.append(f'    {mid}["{mod}"]')
+                rendered_nodes.add(mid)
+            for dep in deps:
+                did = _id(dep)
+                if did not in rendered_nodes:
+                    lines.append(f'    {did}["{dep}"]')
+                    rendered_nodes.add(did)
+                if (mod, dep) in cycle_edges:
+                    lines.append(f"    {mid} -->|cycle| {did}")
+                else:
+                    lines.append(f"    {mid} --> {did}")
+
+        if highlight_cycles and cycle_edges:
+            # Linkstyle for cycle edges (red)
+            cycle_indices = [
+                i for i, line in enumerate(lines)
+                if "-->|cycle|" in line
+            ]
+            for idx in cycle_indices:
+                lines.append(f"    linkStyle {idx - 1} stroke:#ff0000,stroke-width:2px")
+
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return self.model_dump()
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DependencyGraph":
+        return cls(**data)
+
+
+# ---------------------------------------------------------------------------
+# Analyser
+# ---------------------------------------------------------------------------
+
+class DependencyAnalyzer:
+    """Build a ``DependencyGraph`` for the repository at *repo_path*."""
+
+    def __init__(self, repo_path: str | Path) -> None:
+        self.repo_path = Path(repo_path).resolve()
+        if not self.repo_path.is_dir():
+            raise ValueError(f"Not a directory: {self.repo_path}")
+
+    def analyze(self) -> DependencyGraph:
+        language = self._detect_language()
+        logger.info("dep_graph: analysing %s repo at %s", language, self.repo_path)
+
+        if language == "python":
+            return self._analyse_python()
+        if language in {"javascript", "typescript"}:
+            return self._analyse_js_ts(language)
+
+        logger.debug("dep_graph: unsupported language '%s'", language)
+        return DependencyGraph(language=language)
+
+    # ------------------------------------------------------------------
+    # Language detection
+    # ------------------------------------------------------------------
+
+    def _detect_language(self) -> str:
+        if (self.repo_path / "pyproject.toml").exists() or \
+           (self.repo_path / "setup.py").exists():
+            return "python"
+        if (self.repo_path / "tsconfig.json").exists():
+            return "typescript"
+        if (self.repo_path / "package.json").exists():
+            return "javascript"
+        py_count = sum(1 for _ in self._iter_files(_PY_EXTS, limit=10))
+        js_count = sum(1 for _ in self._iter_files(_JS_EXTS | _TS_EXTS, limit=10))
+        return "python" if py_count >= js_count else "javascript"
+
+    # ------------------------------------------------------------------
+    # Python
+    # ------------------------------------------------------------------
+
+    def _analyse_python(self) -> DependencyGraph:
+        """Parse Python import statements via AST."""
+        # Map: module_name (dot-separated) → set of imported module names
+        raw_imports: dict[str, set[str]] = defaultdict(set)
+        # Track ALL discovered module names (including leaf files with no imports)
+        all_modules: set[str] = set()
+        files_ok = 0
+        files_err = 0
+
+        for path in self._iter_files(_PY_EXTS):
+            mod_name = self._py_module_name(path)
+            all_modules.add(mod_name)
+            try:
+                source = path.read_text(encoding="utf-8", errors="replace")
+                tree = ast.parse(source, filename=str(path))
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Import):
+                        for alias in node.names:
+                            raw_imports[mod_name].add(alias.name)
+                    elif isinstance(node, ast.ImportFrom):
+                        if node.module:
+                            # Resolve relative imports to package-relative names
+                            target = self._resolve_relative(mod_name, node.module, node.level or 0)
+                            raw_imports[mod_name].add(target)
+                files_ok += 1
+            except SyntaxError as exc:
+                logger.debug("dep_graph: syntax error in %s: %s", path, exc)
+                files_err += 1
+            except Exception as exc:
+                logger.debug("dep_graph: read error %s: %s", path, exc)
+                files_err += 1
+
+        # Filter: only keep internal modules (those we discovered as files)
+        # Use all_modules (includes leaf files) not raw_imports.keys()
+        filtered: dict[str, set[str]] = {}
+        for mod in all_modules:
+            deps = raw_imports.get(mod, set())
+            internal_deps = {d for d in deps if self._is_internal(d, all_modules)}
+            filtered[mod] = internal_deps
+
+        return self._build_graph(filtered, "python", files_ok, files_err)
+
+    def _py_module_name(self, path: Path) -> str:
+        """Convert a file path to a dotted module name relative to repo root."""
+        try:
+            rel = path.relative_to(self.repo_path)
+        except ValueError:
+            return path.stem
+        parts = list(rel.parts)
+        if parts[-1] == "__init__.py":
+            parts = parts[:-1]
+        elif parts[-1].endswith(".py"):
+            parts[-1] = parts[-1][:-3]
+        return ".".join(parts) if parts else path.stem
+
+    def _resolve_relative(self, current_mod: str, target: str, level: int) -> str:
+        """Resolve a relative import (``from . import x``) to an absolute name."""
+        if level == 0:
+            return target
+        parts = current_mod.split(".")
+        # Go up `level` levels
+        base_parts = parts[: max(0, len(parts) - level)]
+        return ".".join(base_parts + [target]) if target else ".".join(base_parts)
+
+    def _is_internal(self, module: str, known: set[str]) -> bool:
+        """Return True if *module* (or its package prefix) is in *known*."""
+        if module in known:
+            return True
+        # Check package prefix: "app.core" matches "app"
+        prefix = module.split(".")[0]
+        return any(k == prefix or k.startswith(prefix + ".") for k in known)
+
+    # ------------------------------------------------------------------
+    # JS / TS
+    # ------------------------------------------------------------------
+
+    def _analyse_js_ts(self, language: str) -> DependencyGraph:
+        """Parse JS/TS import/require statements via regex."""
+        exts = _TS_EXTS if language == "typescript" else _JS_EXTS | _TS_EXTS
+        raw_imports: dict[str, set[str]] = defaultdict(set)
+        files_ok = 0
+        files_err = 0
+
+        for path in self._iter_files(exts):
+            mod_name = self._js_module_name(path)
+            try:
+                source = path.read_text(encoding="utf-8", errors="replace")
+                for m in _JS_IMPORT_RE.finditer(source):
+                    target = m.group(1) or m.group(2) or m.group(3)
+                    if target and target.startswith("."):
+                        # Relative import — resolve to a module name
+                        resolved = self._resolve_js_relative(path, target)
+                        raw_imports[mod_name].add(resolved)
+                files_ok += 1
+            except Exception as exc:
+                logger.debug("dep_graph: read error %s: %s", path, exc)
+                files_err += 1
+
+        # Filter to only internal modules
+        known = set(raw_imports.keys())
+        filtered = {mod: {d for d in deps if d in known} for mod, deps in raw_imports.items()}
+
+        return self._build_graph(filtered, language, files_ok, files_err)
+
+    def _js_module_name(self, path: Path) -> str:
+        """Return a slash-separated module name relative to repo root."""
+        try:
+            rel = path.relative_to(self.repo_path)
+        except ValueError:
+            return path.stem
+        # Strip extension
+        name = str(rel)
+        for ext in (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"):
+            if name.endswith(ext):
+                name = name[: -len(ext)]
+                break
+        return name
+
+    def _resolve_js_relative(self, current_file: Path, target: str) -> str:
+        """Resolve a relative JS import path to our internal module name."""
+        resolved = (current_file.parent / target).resolve()
+        return self._js_module_name(resolved)
+
+    # ------------------------------------------------------------------
+    # Graph construction
+    # ------------------------------------------------------------------
+
+    def _build_graph(
+        self,
+        raw: dict[str, set[str]],
+        language: str,
+        files_ok: int,
+        files_err: int,
+    ) -> DependencyGraph:
+        imports: dict[str, list[str]] = {m: sorted(deps) for m, deps in raw.items()}
+
+        # Build reverse index (importers)
+        importers: dict[str, list[str]] = defaultdict(list)
+        for mod, deps in imports.items():
+            for dep in deps:
+                importers[dep].append(mod)
+        importers_sorted = {m: sorted(set(v)) for m, v in importers.items()}
+
+        # Ensure every module appears in both dicts
+        all_mods = set(imports.keys()) | set(importers_sorted.keys())
+        for m in all_mods:
+            imports.setdefault(m, [])
+            importers_sorted.setdefault(m, [])
+
+        # Detect cycles
+        cycles = _detect_cycles(imports)
+
+        # Coupling scores
+        n = len(all_mods) or 1
+        coupling: dict[str, float] = {}
+        for mod in all_mods:
+            out_deg = len(imports.get(mod, []))
+            in_deg  = len(importers_sorted.get(mod, []))
+            coupling[mod] = min(1.0, (in_deg + out_deg) / n)
+
+        total_edges = sum(len(v) for v in imports.values())
+        logger.info(
+            "dep_graph: %s — %d modules, %d edges, %d cycle(s), %d files (%d errors)",
+            language, len(all_mods), total_edges, len(cycles), files_ok, files_err,
+        )
+
+        return DependencyGraph(
+            imports=imports,
+            importers=importers_sorted,
+            cycles=cycles,
+            coupling_scores=coupling,
+            language=language,
+            files_analysed=files_ok,
+            parse_errors=files_err,
+        )
+
+    # ------------------------------------------------------------------
+    # File iteration
+    # ------------------------------------------------------------------
+
+    def _iter_files(self, exts: set[str], limit: int = _MAX_FILES) -> Iterator[Path]:
+        count = 0
+        for path in sorted(self.repo_path.rglob("*")):
+            if count >= limit:
+                break
+            if path.is_file() and path.suffix in exts:
+                if not any(part in _SKIP_DIRS for part in path.parts):
+                    yield path
+                    count += 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle detection (DFS)
+# ---------------------------------------------------------------------------
+
+def _detect_cycles(graph: dict[str, list[str]]) -> list[list[str]]:
+    """Return all unique simple cycles in *graph* using iterative DFS.
+
+    Each cycle is represented as the list of nodes forming the loop,
+    e.g. ``["a", "b", "c"]`` means a→b→c→a.
+    """
+    cycles: list[list[str]] = []
+    visited: set[str] = set()
+    rec_stack: set[str] = set()
+    path: list[str] = []
+
+    def _dfs(node: str) -> None:
+        visited.add(node)
+        rec_stack.add(node)
+        path.append(node)
+
+        for neighbour in graph.get(node, []):
+            if neighbour not in visited:
+                _dfs(neighbour)
+            elif neighbour in rec_stack:
+                # Found a back-edge → extract the cycle
+                cycle_start = path.index(neighbour)
+                cycle = path[cycle_start:]
+                # Normalise: rotate so the lexicographically smallest node is first
+                min_idx = cycle.index(min(cycle))
+                normalised = cycle[min_idx:] + cycle[:min_idx]
+                if normalised not in cycles:
+                    cycles.append(normalised)
+
+        path.pop()
+        rec_stack.discard(node)
+
+    for node in sorted(graph.keys()):
+        if node not in visited:
+            _dfs(node)
+
+    return cycles
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+def format_dep_graph_for_prompt(graph: DependencyGraph, max_cycles: int = 5) -> str:
+    """Return a concise, prompt-ready summary of *graph*."""
+    if not graph.all_modules():
+        return "## Dependency Graph\nNo modules detected."
+
+    n_mods  = len(graph.all_modules())
+    n_edges = sum(len(v) for v in graph.imports.values())
+    n_cyc   = len(graph.cycles)
+
+    lines = [
+        f"## Dependency Graph — {n_mods} modules, {n_edges} edges"
+        f", {n_cyc} cycle(s) ({graph.language})",
+        "",
+    ]
+
+    if graph.cycles:
+        lines.append(f"### ⚠️  Circular imports ({min(n_cyc, max_cycles)} shown):")
+        for cycle in graph.cycles[:max_cycles]:
+            lines.append("- " + " → ".join(cycle) + f" → {cycle[0]}")
+        if n_cyc > max_cycles:
+            lines.append(f"  ... and {n_cyc - max_cycles} more")
+        lines.append("")
+
+    top = graph.most_coupled(5)
+    if top:
+        lines.append("### Most-coupled modules (high change risk):")
+        for mod, score in top:
+            lines.append(f"- `{mod}` (coupling={score:.2f})")
+
+    return "\n".join(lines)

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -127,6 +127,13 @@ class GraphState(BaseModel):
     # Keys: callers, callees, file_map, language, files_analysed, parse_errors
     call_graph: dict[str, Any] = Field(default_factory=dict)
 
+    # ── Dependency graph ──────────────────────────────────────────────
+    # Populated by context_loader_node. Serialised DependencyGraph.to_dict().
+    # Keys: imports, importers, cycles, coupling_scores, language, ...
+    dependency_graph: dict[str, Any] = Field(default_factory=dict)
+    # Convenience: detected circular import paths (each path = list[str])
+    dep_cycles: list[list[str]] = Field(default_factory=list)
+
     # ── Metadata ──────────────────────────────────────────────────────
     total_iterations: int = 0
     completed_items: int = 0

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,0 +1,410 @@
+"""Tests for app/analysis/dependency_graph.py"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.analysis.dependency_graph import (
+    DependencyAnalyzer,
+    DependencyGraph,
+    _detect_cycles,
+    format_dep_graph_for_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def simple_py_repo(tmp_path: Path) -> Path:
+    """Three-module repo: main → utils → helpers (no cycles)."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname="test"')
+    (tmp_path / "helpers.py").write_text("# no imports\ndef helper(): pass\n")
+    (tmp_path / "utils.py").write_text("from helpers import helper\ndef util(): pass\n")
+    (tmp_path / "main.py").write_text("from utils import util\nfrom helpers import helper\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def cycle_py_repo(tmp_path: Path) -> Path:
+    """Repo with a circular import: a → b → c → a."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname="test"')
+    (tmp_path / "a.py").write_text("from b import something\n")
+    (tmp_path / "b.py").write_text("from c import something\n")
+    (tmp_path / "c.py").write_text("from a import something\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def package_py_repo(tmp_path: Path) -> Path:
+    """Repo with a package structure: app/__init__.py + app/core.py."""
+    pkg = tmp_path / "app"
+    pkg.mkdir()
+    (tmp_path / "pyproject.toml").write_text('[project]\nname="test"')
+    (pkg / "__init__.py").write_text("")
+    (pkg / "core.py").write_text("# no imports\n")
+    (pkg / "utils.py").write_text("from app.core import something\n")
+    (tmp_path / "main.py").write_text("from app.utils import something\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def js_repo(tmp_path: Path) -> Path:
+    """Simple JS repo: index.js → utils.js."""
+    (tmp_path / "package.json").write_text('{"name":"test"}')
+    (tmp_path / "utils.js").write_text("function helper() {}\nmodule.exports = { helper };\n")
+    (tmp_path / "index.js").write_text("const { helper } = require('./utils');\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def ts_repo(tmp_path: Path) -> Path:
+    """TypeScript repo: src/index.ts → src/lib.ts."""
+    (tmp_path / "tsconfig.json").write_text('{"compilerOptions": {}}')
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lib.ts").write_text("export function libFunc() {}\n")
+    (src / "index.ts").write_text("import { libFunc } from './lib';\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# DependencyGraph model
+# ---------------------------------------------------------------------------
+
+class TestDependencyGraphModel:
+    def test_get_imports(self):
+        dg = DependencyGraph(imports={"a": ["b", "c"]}, importers={"b": ["a"], "c": ["a"]})
+        assert sorted(dg.get_imports("a")) == ["b", "c"]
+        assert dg.get_imports("b") == []
+
+    def test_get_importers(self):
+        dg = DependencyGraph(imports={"a": ["b"]}, importers={"b": ["a"]})
+        assert dg.get_importers("b") == ["a"]
+        assert dg.get_importers("a") == []
+
+    def test_all_modules(self):
+        dg = DependencyGraph(imports={"a": ["b"]}, importers={"b": ["a"]})
+        assert dg.all_modules() == {"a", "b"}
+
+    def test_orphans(self):
+        dg = DependencyGraph(
+            imports={"a": ["b"], "b": [], "orphan": []},
+            importers={"b": ["a"]},
+        )
+        orphans = dg.orphans()
+        assert "orphan" in orphans
+        assert "a" in orphans   # a is not imported by anyone
+        assert "b" not in orphans
+
+    def test_most_coupled(self):
+        dg = DependencyGraph(
+            coupling_scores={"high": 0.9, "mid": 0.5, "low": 0.1},
+        )
+        top = dg.most_coupled(n=2)
+        assert top[0][0] == "high"
+        assert top[1][0] == "mid"
+
+    def test_serialization_roundtrip(self):
+        dg = DependencyGraph(
+            imports={"a": ["b"]},
+            importers={"b": ["a"]},
+            cycles=[["a", "b"]],
+            coupling_scores={"a": 0.5, "b": 0.5},
+            language="python",
+            files_analysed=2,
+            parse_errors=0,
+        )
+        restored = DependencyGraph.from_dict(dg.to_dict())
+        assert restored.imports == dg.imports
+        assert restored.cycles == dg.cycles
+        assert restored.language == dg.language
+
+    def test_to_mermaid_basic(self):
+        dg = DependencyGraph(
+            imports={"a": ["b"], "b": []},
+            importers={"b": ["a"]},
+        )
+        mermaid = dg.to_mermaid()
+        assert "graph TD" in mermaid
+        assert "a" in mermaid
+        assert "b" in mermaid
+        assert "-->" in mermaid
+
+    def test_to_mermaid_cycle_highlighted(self):
+        dg = DependencyGraph(
+            imports={"a": ["b"], "b": ["a"]},
+            importers={"a": ["b"], "b": ["a"]},
+            cycles=[["a", "b"]],
+        )
+        mermaid = dg.to_mermaid(highlight_cycles=True)
+        assert "cycle" in mermaid or "stroke:#ff0000" in mermaid or "-->|cycle|" in mermaid
+
+    def test_to_mermaid_no_modules_safe(self):
+        dg = DependencyGraph()
+        mermaid = dg.to_mermaid()
+        assert "graph TD" in mermaid
+
+
+# ---------------------------------------------------------------------------
+# _detect_cycles
+# ---------------------------------------------------------------------------
+
+class TestDetectCycles:
+    def test_no_cycle(self):
+        graph = {"a": ["b"], "b": ["c"], "c": []}
+        cycles = _detect_cycles(graph)
+        assert cycles == []
+
+    def test_simple_cycle_ab(self):
+        graph = {"a": ["b"], "b": ["a"]}
+        cycles = _detect_cycles(graph)
+        assert len(cycles) == 1
+        assert set(cycles[0]) == {"a", "b"}
+
+    def test_three_node_cycle(self):
+        graph = {"a": ["b"], "b": ["c"], "c": ["a"]}
+        cycles = _detect_cycles(graph)
+        assert len(cycles) == 1
+        assert set(cycles[0]) == {"a", "b", "c"}
+
+    def test_self_loop(self):
+        graph = {"a": ["a"], "b": []}
+        cycles = _detect_cycles(graph)
+        assert any("a" in c for c in cycles)
+
+    def test_no_duplicate_cycles(self):
+        # a→b→a should produce exactly 1 cycle, not 2
+        graph = {"a": ["b"], "b": ["a"], "c": []}
+        cycles = _detect_cycles(graph)
+        assert len(cycles) == 1
+
+    def test_disconnected_graph(self):
+        graph = {"a": ["b"], "b": [], "x": ["y"], "y": []}
+        cycles = _detect_cycles(graph)
+        assert cycles == []
+
+
+# ---------------------------------------------------------------------------
+# Python analysis
+# ---------------------------------------------------------------------------
+
+class TestDependencyAnalyzerPython:
+    def test_detects_language_python(self, simple_py_repo):
+        assert DependencyAnalyzer(simple_py_repo)._detect_language() == "python"
+
+    def test_utils_imports_helpers(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        assert "helpers" in dg.get_imports("utils")
+
+    def test_main_imports_utils_and_helpers(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        imports = dg.get_imports("main")
+        assert "utils" in imports
+        assert "helpers" in imports
+
+    def test_helpers_has_no_imports(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        assert dg.get_imports("helpers") == []
+
+    def test_importers_of_helpers(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        importers = dg.get_importers("helpers")
+        assert "utils" in importers or "main" in importers
+
+    def test_no_cycles_in_simple_repo(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        assert dg.cycles == []
+
+    def test_detects_circular_imports(self, cycle_py_repo):
+        dg = DependencyAnalyzer(cycle_py_repo).analyze()
+        assert len(dg.cycles) >= 1
+        all_cycle_nodes = {n for cycle in dg.cycles for n in cycle}
+        assert "a" in all_cycle_nodes
+        assert "b" in all_cycle_nodes
+        assert "c" in all_cycle_nodes
+
+    def test_package_structure(self, package_py_repo):
+        dg = DependencyAnalyzer(package_py_repo).analyze()
+        # app.utils should import app.core
+        assert dg.files_analysed >= 3
+
+    def test_coupling_scores_between_0_and_1(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        for score in dg.coupling_scores.values():
+            assert 0.0 <= score <= 1.0
+
+    def test_files_analysed_count(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        assert dg.files_analysed == 3
+
+    def test_parse_error_files_skipped(self, simple_py_repo):
+        (simple_py_repo / "broken.py").write_text("def foo(\n  # broken")
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        assert dg.parse_errors >= 1
+        assert dg.files_analysed >= 3
+
+    def test_language_is_python(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        assert dg.language == "python"
+
+    def test_self_analysis_does_not_crash(self):
+        """Analyzer must handle the Daedalus repo itself without crashing."""
+        root = Path(__file__).parent.parent
+        dg = DependencyAnalyzer(root).analyze()
+        assert dg.language == "python"
+        assert dg.files_analysed > 0
+
+    def test_syntax_only_repo(self, tmp_path):
+        """Repo with only stdlib imports produces empty internal graph."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nname="test"')
+        (tmp_path / "standalone.py").write_text("import os\nimport sys\n")
+        dg = DependencyAnalyzer(tmp_path).analyze()
+        # os/sys are external → no internal edges
+        assert dg.get_imports("standalone") == []
+
+
+# ---------------------------------------------------------------------------
+# JS analysis
+# ---------------------------------------------------------------------------
+
+class TestDependencyAnalyzerJS:
+    def test_detects_language_javascript(self, js_repo):
+        assert DependencyAnalyzer(js_repo)._detect_language() == "javascript"
+
+    def test_index_imports_utils(self, js_repo):
+        dg = DependencyAnalyzer(js_repo).analyze()
+        # index.js requires('./utils') → internal dep on utils
+        index_key = next((k for k in dg.imports if "index" in k), None)
+        utils_key = next((k for k in dg.all_modules() if "utils" in k), None)
+        if index_key and utils_key:
+            assert utils_key in dg.get_imports(index_key)
+
+    def test_language_is_javascript(self, js_repo):
+        dg = DependencyAnalyzer(js_repo).analyze()
+        assert dg.language == "javascript"
+
+    def test_no_external_packages_in_imports(self, js_repo):
+        # External packages (no ./ prefix) should not appear as internal nodes
+        (js_repo / "app.js").write_text("const express = require('express');\n")
+        dg = DependencyAnalyzer(js_repo).analyze()
+        assert "express" not in dg.all_modules()
+
+
+# ---------------------------------------------------------------------------
+# TS analysis
+# ---------------------------------------------------------------------------
+
+class TestDependencyAnalyzerTS:
+    def test_detects_language_typescript(self, ts_repo):
+        assert DependencyAnalyzer(ts_repo)._detect_language() == "typescript"
+
+    def test_index_imports_lib(self, ts_repo):
+        dg = DependencyAnalyzer(ts_repo).analyze()
+        assert dg.files_analysed == 2
+
+    def test_language_is_typescript(self, ts_repo):
+        dg = DependencyAnalyzer(ts_repo).analyze()
+        assert dg.language == "typescript"
+
+
+# ---------------------------------------------------------------------------
+# Skip dirs
+# ---------------------------------------------------------------------------
+
+class TestSkipDirs:
+    def test_node_modules_skipped(self, js_repo):
+        nm = js_repo / "node_modules" / "lib"
+        nm.mkdir(parents=True)
+        (nm / "secret.js").write_text("const x = require('./other');")
+        dg = DependencyAnalyzer(js_repo).analyze()
+        # secret module should not appear
+        assert not any("secret" in m for m in dg.all_modules())
+
+    def test_venv_skipped(self, simple_py_repo):
+        venv = simple_py_repo / ".venv" / "lib"
+        venv.mkdir(parents=True)
+        (venv / "hidden.py").write_text("from utils import util\n")
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        assert not any("hidden" in m for m in dg.all_modules())
+
+
+# ---------------------------------------------------------------------------
+# format_dep_graph_for_prompt
+# ---------------------------------------------------------------------------
+
+class TestFormatDepGraphForPrompt:
+    def test_empty_graph(self):
+        dg = DependencyGraph()
+        result = format_dep_graph_for_prompt(dg)
+        assert "No modules detected" in result
+
+    def test_includes_header(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        result = format_dep_graph_for_prompt(dg)
+        assert "Dependency Graph" in result
+        assert "modules" in result
+
+    def test_reports_cycles(self, cycle_py_repo):
+        dg = DependencyAnalyzer(cycle_py_repo).analyze()
+        result = format_dep_graph_for_prompt(dg)
+        assert "Circular" in result or "cycle" in result.lower()
+
+    def test_no_cycles_message_clean(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        result = format_dep_graph_for_prompt(dg)
+        assert "Circular" not in result
+
+    def test_shows_coupling(self, simple_py_repo):
+        dg = DependencyAnalyzer(simple_py_repo).analyze()
+        result = format_dep_graph_for_prompt(dg)
+        assert "coupling" in result.lower() or "coupled" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# GraphState integration
+# ---------------------------------------------------------------------------
+
+class TestGraphStateDepGraph:
+    def test_dependency_graph_field_exists(self):
+        from app.core.state import GraphState
+        state = GraphState()
+        assert hasattr(state, "dependency_graph")
+        assert state.dependency_graph == {}
+
+    def test_dep_cycles_field_exists(self):
+        from app.core.state import GraphState
+        state = GraphState()
+        assert hasattr(state, "dep_cycles")
+        assert state.dep_cycles == []
+
+    def test_fields_accept_data(self):
+        from app.core.state import GraphState
+        dg = DependencyGraph(
+            imports={"a": ["b"]},
+            importers={"b": ["a"]},
+            cycles=[["a", "b"]],
+            language="python",
+        )
+        state = GraphState(
+            dependency_graph=dg.to_dict(),
+            dep_cycles=dg.cycles,
+        )
+        assert state.dependency_graph["language"] == "python"
+        assert state.dep_cycles == [["a", "b"]]
+
+    def test_fields_serialize(self):
+        from app.core.state import GraphState
+        state = GraphState(
+            dependency_graph={"imports": {}, "importers": {}, "cycles": [],
+                              "coupling_scores": {}, "language": "python",
+                              "files_analysed": 1, "parse_errors": 0},
+            dep_cycles=[["x", "y"]],
+        )
+        dumped = state.model_dump()
+        assert "dependency_graph" in dumped
+        assert "dep_cycles" in dumped
+        assert dumped["dep_cycles"] == [["x", "y"]]


### PR DESCRIPTION
- Add app/analysis/dependency_graph.py with DependencyAnalyzer + DependencyGraph
- Python: two-pass AST — collect all file-level modules first (incl. leaves), then parse import/from statements; resolves relative imports correctly
- JS/TS: regex-based require() + import ... from ... with relative path resolution
- _detect_cycles(): iterative DFS with normalised cycle deduplication
- DependencyGraph.to_mermaid(): graph TD with cycle edges highlighted in red
- Coupling score per module: (in_degree + out_degree) / total_modules, 0.0–1.0
- Add dependency_graph: dict[str, Any] + dep_cycles: list[list[str]] to GraphState
- Wire into context_loader_node after call graph analysis (best-effort)
- Inject into planner prompt (cycles + top-5 coupled) and coder prompt (top-5)
- Add _format_dep_graph_for_prompt() helper in nodes.py
- Add GET /api/dependency-graph endpoint (mermaid + json + cycles + stats)
- 47 new tests in tests/test_dependency_graph.py — 368 total, 0 failures

Closes #13