### PR TITLE
feat(analysis): code smell detection — 8 AST-based rules

### DIFF
--- a/app/analysis/smell_detector.py
+++ b/app/analysis/smell_detector.py
@@ -1,0 +1,454 @@
+"""Code smell detection — 8 AST-based rules for Python.
+
+All analysis runs in-process using the standard ``ast`` module.
+No shell tools, no subprocesses, no external dependencies.
+
+Rules
+-----
+1. Long Function      — function body > 50 lines (WARNING) or > 100 lines (ERROR)
+2. High Complexity    — cyclomatic complexity > 10 (ERROR)
+3. God Class          — class with > 20 methods or > 500 lines (ERROR)
+4. Long Parameter List — function with > 5 parameters (WARNING)
+5. Duplicate Code     — two functions whose non-blank bodies are ≥ 80 % identical (WARNING)
+6. Dead Code          — function defined but never called (needs call-graph data, INFO)
+7. Magic Numbers      — numeric literals outside assignments to named constants (INFO)
+8. Deeply Nested      — statement nesting depth > 4 levels (WARNING)
+
+Public API
+----------
+``SmellDetector(repo_path, call_graph=None)``
+    Accepts an optional ``CallGraph`` dict (from #12) to enable dead-code detection.
+    Call ``detect()`` → ``list[CodeSmell]``.
+
+``CodeSmell``
+    Pydantic model: file, line, smell_type, severity, description, suggestion.
+
+``format_smells_for_prompt(smells, max_smells=10)``
+    Returns a compact, prompt-ready summary.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from itertools import combinations
+from pathlib import Path
+from typing import Iterator, Literal
+
+from pydantic import BaseModel, Field
+
+from app.core.logging import get_logger
+
+logger = get_logger("analysis.smell_detector")
+
+Severity = Literal["error", "warning", "info"]
+
+_SKIP_DIRS = {
+    ".git", "__pycache__", ".pytest_cache", ".ruff_cache",
+    "node_modules", ".venv", "venv", ".tox", "dist", "build", ".daedalus",
+}
+_MAX_FILES = 500
+
+# Thresholds
+_LONG_FUNC_WARN  = 50
+_LONG_FUNC_ERROR = 100
+_HIGH_COMPLEXITY = 10
+_GOD_CLASS_METHODS = 20
+_GOD_CLASS_LINES   = 500
+_LONG_PARAM_COUNT  = 5
+_DUPLICATE_THRESH  = 0.75   # 75 % similarity
+_MAX_NESTING       = 4
+# Magic-number whitelist (values so common they're not smells)
+_MAGIC_WHITELIST: frozenset[complex] = frozenset({0, 1, -1, 2, 100})
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+class CodeSmell(BaseModel):
+    """A single code smell finding."""
+
+    file: str
+    line: int = 0
+    smell_type: str            # rule name, e.g. "LongFunction"
+    severity: Severity = "warning"
+    description: str
+    suggestion: str = ""
+
+    def one_line(self) -> str:
+        sev = self.severity.upper()
+        return (
+            f"[{sev}] {self.smell_type} @ {self.file}:{self.line} — "
+            f"{self.description}"
+            + (f" | FIX: {self.suggestion}" if self.suggestion else "")
+        )
+
+
+_SEV_ORDER = {"error": 0, "warning": 1, "info": 2}
+
+
+def sort_smells(smells: list[CodeSmell]) -> list[CodeSmell]:
+    return sorted(smells, key=lambda s: (_SEV_ORDER.get(s.severity, 9), s.file, s.line))
+
+
+# ---------------------------------------------------------------------------
+# Detector
+# ---------------------------------------------------------------------------
+
+class SmellDetector:
+    """Detect code smells in a Python repository."""
+
+    def __init__(self, repo_path: str | Path, call_graph: dict | None = None) -> None:
+        self.repo_path = Path(repo_path).resolve()
+        self._call_graph = call_graph or {}
+
+    def detect(self) -> list[CodeSmell]:
+        """Run all 8 rules and return sorted findings."""
+        smells: list[CodeSmell] = []
+        trees: list[tuple[str, ast.Module, list[str]]] = []
+
+        for path in self._iter_files():
+            rel = str(path.relative_to(self.repo_path))
+            try:
+                source = path.read_text(encoding="utf-8", errors="replace")
+                tree = ast.parse(source, filename=str(path))
+                lines = source.splitlines()
+                trees.append((rel, tree, lines))
+            except SyntaxError:
+                logger.debug("smell: syntax error in %s, skipping", rel)
+            except Exception as exc:
+                logger.debug("smell: could not read %s: %s", rel, exc)
+
+        for rel, tree, lines in trees:
+            smells.extend(_rule_long_function(rel, tree, lines))
+            smells.extend(_rule_high_complexity(rel, tree))
+            smells.extend(_rule_god_class(rel, tree, lines))
+            smells.extend(_rule_long_param_list(rel, tree))
+            smells.extend(_rule_deeply_nested(rel, tree))
+            smells.extend(_rule_magic_numbers(rel, tree))
+            smells.extend(_rule_dead_code(rel, tree, self._call_graph))
+
+        # Rule 5: duplicate code across all files (needs all trees)
+        smells.extend(_rule_duplicate_code(trees))
+
+        logger.info(
+            "smell: %d smells found (%d error, %d warning, %d info)",
+            len(smells),
+            sum(1 for s in smells if s.severity == "error"),
+            sum(1 for s in smells if s.severity == "warning"),
+            sum(1 for s in smells if s.severity == "info"),
+        )
+        return sort_smells(smells)
+
+    def _iter_files(self, limit: int = _MAX_FILES) -> Iterator[Path]:
+        count = 0
+        for path in sorted(self.repo_path.rglob("*.py")):
+            if count >= limit:
+                break
+            if not any(part in _SKIP_DIRS for part in path.parts):
+                yield path
+                count += 1
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — Long Function
+# ---------------------------------------------------------------------------
+
+def _rule_long_function(rel: str, tree: ast.Module, lines: list[str]) -> list[CodeSmell]:
+    smells = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        end = getattr(node, "end_lineno", None)
+        if end is None:
+            continue
+        length = end - node.lineno + 1
+        if length > _LONG_FUNC_ERROR:
+            smells.append(CodeSmell(
+                file=rel, line=node.lineno, smell_type="LongFunction", severity="error",
+                description=f"`{node.name}` is {length} lines long (limit {_LONG_FUNC_ERROR})",
+                suggestion="Extract helper functions to reduce size below 50 lines.",
+            ))
+        elif length > _LONG_FUNC_WARN:
+            smells.append(CodeSmell(
+                file=rel, line=node.lineno, smell_type="LongFunction", severity="warning",
+                description=f"`{node.name}` is {length} lines long (limit {_LONG_FUNC_WARN})",
+                suggestion="Consider splitting into smaller focused functions.",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — High Complexity (cyclomatic)
+# ---------------------------------------------------------------------------
+
+def _cyclomatic_complexity(func: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    """Cyclomatic complexity = 1 + number of branches."""
+    branch_nodes = (
+        ast.If, ast.For, ast.While, ast.ExceptHandler,
+        ast.With, ast.Assert, ast.comprehension,
+    )
+    count = 1
+    for node in ast.walk(func):
+        if isinstance(node, branch_nodes):
+            count += 1
+        # BoolOp: each 'and'/'or' adds a path
+        elif isinstance(node, ast.BoolOp):
+            count += len(node.values) - 1
+    return count
+
+
+def _rule_high_complexity(rel: str, tree: ast.Module) -> list[CodeSmell]:
+    smells = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        cc = _cyclomatic_complexity(node)
+        if cc > _HIGH_COMPLEXITY:
+            smells.append(CodeSmell(
+                file=rel, line=node.lineno, smell_type="HighComplexity", severity="error",
+                description=f"`{node.name}` has cyclomatic complexity {cc} (limit {_HIGH_COMPLEXITY})",
+                suggestion="Break into smaller functions; reduce branching and boolean chains.",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — God Class
+# ---------------------------------------------------------------------------
+
+def _rule_god_class(rel: str, tree: ast.Module, lines: list[str]) -> list[CodeSmell]:
+    smells = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        methods = [n for n in ast.walk(node) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+        end = getattr(node, "end_lineno", node.lineno)
+        class_lines = end - node.lineno + 1
+
+        reasons = []
+        if len(methods) > _GOD_CLASS_METHODS:
+            reasons.append(f"{len(methods)} methods (limit {_GOD_CLASS_METHODS})")
+        if class_lines > _GOD_CLASS_LINES:
+            reasons.append(f"{class_lines} lines (limit {_GOD_CLASS_LINES})")
+
+        if reasons:
+            smells.append(CodeSmell(
+                file=rel, line=node.lineno, smell_type="GodClass", severity="error",
+                description=f"`{node.name}` is a God Class: {', '.join(reasons)}",
+                suggestion="Split responsibilities into smaller, focused classes (SRP).",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — Long Parameter List
+# ---------------------------------------------------------------------------
+
+def _rule_long_param_list(rel: str, tree: ast.Module) -> list[CodeSmell]:
+    smells = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        args = node.args
+        # Count all param kinds except *args and **kwargs markers themselves
+        param_count = (
+            len(args.args)
+            + len(args.posonlyargs)
+            + len(args.kwonlyargs)
+            + (1 if args.vararg else 0)
+            + (1 if args.kwarg else 0)
+        )
+        # Exclude 'self' / 'cls'
+        if args.args and args.args[0].arg in {"self", "cls"}:
+            param_count -= 1
+
+        if param_count > _LONG_PARAM_COUNT:
+            smells.append(CodeSmell(
+                file=rel, line=node.lineno, smell_type="LongParameterList", severity="warning",
+                description=f"`{node.name}` has {param_count} parameters (limit {_LONG_PARAM_COUNT})",
+                suggestion="Introduce a parameter object or use **kwargs with clear documentation.",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — Duplicate Code
+# ---------------------------------------------------------------------------
+
+def _body_fingerprint(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Return non-blank source lines of function body for similarity comparison."""
+    lines = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            continue  # skip docstrings
+        lines.append(ast.dump(node))
+    return lines
+
+
+def _similarity(a: list[str], b: list[str]) -> float:
+    """Jaccard-like similarity between two fingerprints."""
+    if not a or not b:
+        return 0.0
+    set_a, set_b = set(a), set(b)
+    intersection = len(set_a & set_b)
+    union = len(set_a | set_b)
+    return intersection / union if union else 0.0
+
+
+def _rule_duplicate_code(
+    trees: list[tuple[str, ast.Module, list[str]]],
+) -> list[CodeSmell]:
+    # Collect all functions with their fingerprints
+    funcs: list[tuple[str, int, str, list[str]]] = []  # (rel, line, name, fingerprint)
+    for rel, tree, _ in trees:
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                fp = _body_fingerprint(node)
+                if len(fp) >= 5:  # skip trivial functions
+                    funcs.append((rel, node.lineno, node.name, fp))
+
+    smells = []
+    reported: set[frozenset] = set()
+    for (rel_a, line_a, name_a, fp_a), (rel_b, line_b, name_b, fp_b) in combinations(funcs, 2):
+        if name_a == name_b:
+            continue  # overrides are expected
+        pair = frozenset({(rel_a, line_a), (rel_b, line_b)})
+        if pair in reported:
+            continue
+        sim = _similarity(fp_a, fp_b)
+        if sim >= _DUPLICATE_THRESH:
+            reported.add(pair)
+            smells.append(CodeSmell(
+                file=rel_a, line=line_a, smell_type="DuplicateCode", severity="warning",
+                description=(
+                    f"`{name_a}` ({rel_a}:{line_a}) and `{name_b}` ({rel_b}:{line_b}) "
+                    f"are {sim:.0%} similar"
+                ),
+                suggestion="Extract shared logic into a common helper function.",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Rule 6 — Dead Code (uses call graph from #12)
+# ---------------------------------------------------------------------------
+
+def _rule_dead_code(rel: str, tree: ast.Module, call_graph: dict) -> list[CodeSmell]:
+    if not call_graph:
+        return []
+
+    callers: dict = call_graph.get("callers", {})
+    smells = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        name = node.name
+        # Skip dunder methods, test functions, and well-known entry points
+        if name.startswith("__") or name.startswith("test_") or name in {"main", "setup", "teardown"}:
+            continue
+        # Dead if it has no callers in the graph
+        if name in call_graph.get("callees", {}) and not callers.get(name):
+            smells.append(CodeSmell(
+                file=rel, line=node.lineno, smell_type="DeadCode", severity="info",
+                description=f"`{name}` is defined but never called",
+                suggestion="Remove or export this function if it is unused.",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Rule 7 — Magic Numbers
+# ---------------------------------------------------------------------------
+
+_MAGIC_SKIP_CONTEXTS = (ast.AnnAssign, ast.Assign)
+
+
+def _rule_magic_numbers(rel: str, tree: ast.Module) -> list[CodeSmell]:
+    smells = []
+    # Only flag literals inside function bodies, not module-level constants
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Constant):
+                continue
+            val = node.value
+            if not isinstance(val, (int, float)):
+                continue
+            if val in _MAGIC_WHITELIST:
+                continue
+            smells.append(CodeSmell(
+                file=rel, line=node.col_offset and getattr(node, "lineno", 0),
+                smell_type="MagicNumber", severity="info",
+                description=f"Magic number `{val}` used directly in `{func.name}`",
+                suggestion=f"Replace with a named constant, e.g. `MAX_VALUE = {val}`.",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Rule 8 — Deeply Nested
+# ---------------------------------------------------------------------------
+
+_NESTING_NODES = (ast.If, ast.For, ast.While, ast.With, ast.Try, ast.ExceptHandler)
+
+
+def _max_nesting_depth(node: ast.AST, current: int = 0) -> int:
+    """Recursively find the maximum nesting depth of branching/looping nodes."""
+    if isinstance(node, _NESTING_NODES):
+        current += 1
+    max_depth = current
+    for child in ast.iter_child_nodes(node):
+        max_depth = max(max_depth, _max_nesting_depth(child, current))
+    return max_depth
+
+
+def _rule_deeply_nested(rel: str, tree: ast.Module) -> list[CodeSmell]:
+    smells = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        depth = _max_nesting_depth(node)
+        if depth > _MAX_NESTING:
+            smells.append(CodeSmell(
+                file=rel, line=node.lineno, smell_type="DeeplyNested", severity="warning",
+                description=f"`{node.name}` has nesting depth {depth} (limit {_MAX_NESTING})",
+                suggestion="Use early returns, extract nested blocks into helper functions.",
+            ))
+    return smells
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+def format_smells_for_prompt(smells: list[CodeSmell], max_smells: int = 10) -> str:
+    """Return a concise, prompt-ready summary of *smells*."""
+    if not smells:
+        return "## Code Smells\nNo smells detected."
+
+    errors   = [s for s in smells if s.severity == "error"]
+    warnings = [s for s in smells if s.severity == "warning"]
+    infos    = [s for s in smells if s.severity == "info"]
+
+    selected = (errors + warnings + infos)[:max_smells]
+    total    = len(smells)
+    shown    = len(selected)
+
+    header = (
+        f"## Code Smells — {len(errors)} error(s)"
+        f", {len(warnings)} warning(s)"
+        f", {len(infos)} info(s)"
+    )
+    if total > shown:
+        header += f" (showing top {shown} of {total})"
+
+    lines = [header, ""]
+    for smell in selected:
+        lines.append(f"- {smell.one_line()}")
+
+    return "\n".join(lines)

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -134,6 +134,11 @@ class GraphState(BaseModel):
     # Convenience: detected circular import paths (each path = list[str])
     dep_cycles: list[list[str]] = Field(default_factory=list)
 
+    # ── Code smells ───────────────────────────────────────────────────
+    # Populated by context_loader_node. Each entry is a CodeSmell.model_dump().
+    # Sorted: errors first, then warnings, then info.
+    code_smells: list[dict[str, Any]] = Field(default_factory=list)
+
     # ── Metadata ──────────────────────────────────────────────────────
     total_iterations: int = 0
     completed_items: int = 0

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -291,6 +291,21 @@ async def get_status():
     )
 
 
+@app.get("/api/code-smells")
+async def get_code_smells():
+    """Return code smell findings for the current repo."""
+    if not _current_state or not _current_state.code_smells:
+        return {"smells": [], "total": 0, "errors": 0, "warnings": 0, "infos": 0}
+    smells = _current_state.code_smells
+    return {
+        "smells": smells,
+        "total": len(smells),
+        "errors":   sum(1 for s in smells if s.get("severity") == "error"),
+        "warnings": sum(1 for s in smells if s.get("severity") == "warning"),
+        "infos":    sum(1 for s in smells if s.get("severity") == "info"),
+    }
+
+
 @app.get("/api/dependency-graph")
 async def get_dependency_graph():
     """Return the dependency graph for the current repo as JSON + Mermaid."""

--- a/tests/fixtures/smelly_module.py
+++ b/tests/fixtures/smelly_module.py
@@ -1,0 +1,181 @@
+"""Fixture module with intentionally bad code to trigger all 8 smell rules.
+
+Used exclusively by tests/test_smell_detector.py — not production code.
+
+Expected smells:
+- LongFunction      → very_long_function (> 50 lines)
+- HighComplexity    → complex_function (> 10 branches)
+- GodClass          → BigClass (> 20 methods)
+- LongParameterList → many_params (> 5 params)
+- DuplicateCode     → dup_alpha / dup_beta (≥ 80 % similar)
+- DeadCode          → orphan_func (never called — requires call graph)
+- MagicNumber       → uses_magic (literal 42 in function body)
+- DeeplyNested      → deeply_nested_func (depth > 4)
+"""
+
+
+# ── Rule 1: Long Function (> 50 lines) ──────────────────────────────────────
+def very_long_function(x):
+    a = x + 1
+    b = a + 2
+    c = b + 3
+    d = c + 4
+    e = d + 5
+    f = e + 6
+    g = f + 7
+    h = g + 8
+    i = h + 9
+    j = i + 10
+    k = j + 11
+    l = k + 12
+    m = l + 13
+    n = m + 14
+    o = n + 15
+    p = o + 16
+    q = p + 17
+    r = q + 18
+    s = r + 19
+    t = s + 20
+    u = t + 21
+    v = u + 22
+    w = v + 23
+    x2 = w + 24
+    y = x2 + 25
+    z = y + 26
+    aa = z + 27
+    bb = aa + 28
+    cc = bb + 29
+    dd = cc + 30
+    ee = dd + 31
+    ff = ee + 32
+    gg = ff + 33
+    hh = gg + 34
+    ii = hh + 35
+    jj = ii + 36
+    kk = jj + 37
+    ll = kk + 38
+    mm = ll + 39
+    nn = mm + 40
+    oo = nn + 41
+    pp = oo + 42
+    qq = pp + 43
+    rr = qq + 44
+    ss = rr + 45
+    tt = ss + 46
+    uu = tt + 47
+    vv = uu + 48
+    ww = vv + 49
+    xx = ww + 50
+    yy = xx + 51
+    return yy
+
+
+# ── Rule 2: High Complexity (> 10 branches) ─────────────────────────────────
+def complex_function(a, b, c, d, e):
+    if a > 0:
+        if b > 0:
+            if c > 0:
+                result = a + b + c
+            else:
+                result = a + b
+        elif d > 0:
+            result = a + d
+        else:
+            result = a
+    elif b > 0:
+        if c > 0 and d > 0:
+            result = b + c + d
+        elif e > 0:
+            result = b + e
+        else:
+            result = b
+    else:
+        result = 0
+    for i in range(result):
+        if i % 2 == 0 or i % 3 == 0:
+            result += 1
+    while result > 100:
+        result -= 1
+    return result
+
+
+# ── Rule 3: God Class (> 20 methods) ────────────────────────────────────────
+class BigClass:
+    def method_01(self): pass
+    def method_02(self): pass
+    def method_03(self): pass
+    def method_04(self): pass
+    def method_05(self): pass
+    def method_06(self): pass
+    def method_07(self): pass
+    def method_08(self): pass
+    def method_09(self): pass
+    def method_10(self): pass
+    def method_11(self): pass
+    def method_12(self): pass
+    def method_13(self): pass
+    def method_14(self): pass
+    def method_15(self): pass
+    def method_16(self): pass
+    def method_17(self): pass
+    def method_18(self): pass
+    def method_19(self): pass
+    def method_20(self): pass
+    def method_21(self): pass  # exceeds limit of 20
+
+
+# ── Rule 4: Long Parameter List (> 5 params) ─────────────────────────────────
+def many_params(a, b, c, d, e, f, g):
+    return a + b + c + d + e + f + g
+
+
+# ── Rule 5: Duplicate Code (≥ 80 % similar bodies) ──────────────────────────
+def dup_alpha(items):
+    result = []
+    for item in items:
+        if item > 0:
+            value = item * 2
+            result.append(value)
+        else:
+            value = item * -1
+            result.append(value)
+    total = sum(result)
+    return total
+
+
+def dup_beta(elements):
+    result = []
+    for item in elements:
+        if item > 0:
+            value = item * 2
+            result.append(value)
+        else:
+            value = item * -1
+            result.append(value)
+    total = sum(result)
+    return total
+
+
+# ── Rule 6: Dead Code ────────────────────────────────────────────────────────
+def orphan_func():
+    """This function is never called — requires call-graph data to detect."""
+    return "I am dead code"
+
+
+# ── Rule 7: Magic Numbers ────────────────────────────────────────────────────
+def uses_magic(x):
+    threshold = x * 42          # magic: 42
+    offset = threshold + 999    # magic: 999
+    return offset
+
+
+# ── Rule 8: Deeply Nested (depth > 4) ───────────────────────────────────────
+def deeply_nested_func(data):
+    result = []
+    for item in data:              # depth 1
+        if item:                   # depth 2
+            for sub in item:       # depth 3
+                if sub:            # depth 4
+                    for x in sub:  # depth 5 — exceeds limit
+                        result.append(x)
+    return result

--- a/tests/test_smell_detector.py
+++ b/tests/test_smell_detector.py
@@ -1,0 +1,522 @@
+"""Tests for app/analysis/smell_detector.py — all 8 rules."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from app.analysis.smell_detector import (
+    CodeSmell,
+    SmellDetector,
+    _cyclomatic_complexity,
+    _max_nesting_depth,
+    _rule_dead_code,
+    _rule_deeply_nested,
+    _rule_duplicate_code,
+    _rule_god_class,
+    _rule_high_complexity,
+    _rule_long_function,
+    _rule_long_param_list,
+    _rule_magic_numbers,
+    _similarity,
+    format_smells_for_prompt,
+    sort_smells,
+)
+import ast
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def parse(source: str) -> ast.Module:
+    return ast.parse(textwrap.dedent(source))
+
+
+def make_repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname="test"')
+    for name, src in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(src))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# CodeSmell model
+# ---------------------------------------------------------------------------
+
+class TestCodeSmellModel:
+    def test_one_line_format(self):
+        s = CodeSmell(file="a.py", line=10, smell_type="LongFunction",
+                      severity="error", description="too long", suggestion="split it")
+        line = s.one_line()
+        assert "[ERROR]" in line
+        assert "LongFunction" in line
+        assert "a.py:10" in line
+        assert "split it" in line
+
+    def test_one_line_no_suggestion(self):
+        s = CodeSmell(file="b.py", line=5, smell_type="MagicNumber",
+                      severity="info", description="magic 42")
+        assert "| FIX:" not in s.one_line()
+
+    def test_severity_default(self):
+        s = CodeSmell(file="x.py", line=1, smell_type="T", description="d")
+        assert s.severity == "warning"
+
+
+class TestSortSmells:
+    def test_errors_first(self):
+        smells = [
+            CodeSmell(file="a", line=1, smell_type="T", severity="info", description="i"),
+            CodeSmell(file="a", line=2, smell_type="T", severity="error", description="e"),
+            CodeSmell(file="a", line=3, smell_type="T", severity="warning", description="w"),
+        ]
+        sorted_ = sort_smells(smells)
+        assert sorted_[0].severity == "error"
+        assert sorted_[1].severity == "warning"
+        assert sorted_[2].severity == "info"
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — Long Function
+# ---------------------------------------------------------------------------
+
+class TestRuleLongFunction:
+    def _make_tree(self, n_lines: int) -> tuple[ast.Module, list[str]]:
+        body = "\n".join(f"    x_{i} = {i}" for i in range(n_lines))
+        src = f"def big(x):\n{body}\n    return x\n"
+        return ast.parse(src), src.splitlines()
+
+    def test_no_smell_under_50(self):
+        tree, lines = self._make_tree(40)
+        smells = _rule_long_function("f.py", tree, lines)
+        assert smells == []
+
+    def test_warning_51_lines(self):
+        tree, lines = self._make_tree(51)
+        smells = _rule_long_function("f.py", tree, lines)
+        assert any(s.severity == "warning" and s.smell_type == "LongFunction" for s in smells)
+
+    def test_error_over_100(self):
+        tree, lines = self._make_tree(105)
+        smells = _rule_long_function("f.py", tree, lines)
+        assert any(s.severity == "error" and s.smell_type == "LongFunction" for s in smells)
+
+    def test_fixture_detected(self, tmp_path):
+        repo = make_repo(tmp_path, {"big.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "LongFunction" for s in smells)
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — High Complexity
+# ---------------------------------------------------------------------------
+
+class TestRuleHighComplexity:
+    def test_simple_func_low_complexity(self):
+        tree = parse("def f(x): return x + 1\n")
+        smells = _rule_high_complexity("f.py", tree)
+        assert smells == []
+
+    def test_complexity_counting(self):
+        src = """
+        def f(a, b, c):
+            if a:
+                if b:
+                    pass
+                elif c:
+                    pass
+            for i in range(10):
+                if i > 5:
+                    pass
+            while a and b:
+                a -= 1
+            return a
+        """
+        func = parse(src).body[0]
+        cc = _cyclomatic_complexity(func)
+        assert cc > 5
+
+    def test_high_complexity_flagged(self, tmp_path):
+        repo = make_repo(tmp_path, {"smelly.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "HighComplexity" for s in smells)
+
+    def test_boolop_adds_to_complexity(self):
+        src = "def f(a, b, c): return a and b and c\n"
+        func = parse(src).body[0]
+        cc = _cyclomatic_complexity(func)
+        assert cc >= 3  # 1 + 2 boolean values
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — God Class
+# ---------------------------------------------------------------------------
+
+class TestRuleGodClass:
+    def _make_class(self, n_methods: int) -> ast.Module:
+        methods = "\n".join(f"    def m{i}(self): pass" for i in range(n_methods))
+        return parse(f"class C:\n{methods}\n")
+
+    def test_small_class_no_smell(self):
+        tree = self._make_class(5)
+        smells = _rule_god_class("f.py", tree, [])
+        assert smells == []
+
+    def test_21_methods_flagged(self):
+        tree = self._make_class(21)
+        smells = _rule_god_class("f.py", tree, [])
+        assert any(s.smell_type == "GodClass" and s.severity == "error" for s in smells)
+
+    def test_fixture_god_class_detected(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "GodClass" for s in smells)
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — Long Parameter List
+# ---------------------------------------------------------------------------
+
+class TestRuleLongParamList:
+    def test_5_params_no_smell(self):
+        tree = parse("def f(a, b, c, d, e): pass\n")
+        smells = _rule_long_param_list("f.py", tree)
+        assert smells == []
+
+    def test_6_params_flagged(self):
+        tree = parse("def f(a, b, c, d, e, g): pass\n")
+        smells = _rule_long_param_list("f.py", tree)
+        assert any(s.smell_type == "LongParameterList" for s in smells)
+
+    def test_self_not_counted(self):
+        tree = parse("class C:\n    def f(self, a, b, c, d, e): pass\n")
+        smells = _rule_long_param_list("f.py", tree)
+        assert smells == []
+
+    def test_fixture_detected(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "LongParameterList" for s in smells)
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — Duplicate Code
+# ---------------------------------------------------------------------------
+
+class TestRuleDuplicateCode:
+    def test_identical_functions_flagged(self, tmp_path):
+        src = """
+        def alpha(items):
+            result = []
+            for item in items:
+                if item > 0:
+                    value = item * 2
+                    result.append(value)
+                else:
+                    value = item * -1
+                    result.append(value)
+            total = sum(result)
+            return total
+
+        def beta(elements):
+            result = []
+            for item in elements:
+                if item > 0:
+                    value = item * 2
+                    result.append(value)
+                else:
+                    value = item * -1
+                    result.append(value)
+            total = sum(result)
+            return total
+        """
+        repo = make_repo(tmp_path, {"dup.py": src})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "DuplicateCode" for s in smells)
+
+    def test_different_functions_not_flagged(self, tmp_path):
+        src = """
+        def add(a, b):
+            return a + b
+
+        def multiply(a, b):
+            return a * b
+        """
+        repo = make_repo(tmp_path, {"clean.py": src})
+        smells = SmellDetector(repo).detect()
+        assert not any(s.smell_type == "DuplicateCode" for s in smells)
+
+    def test_similarity_function(self):
+        a = ["x", "y", "z", "w"]
+        b = ["x", "y", "z", "q"]
+        sim = _similarity(a, b)
+        assert 0.5 < sim < 1.0
+
+    def test_similarity_identical(self):
+        a = ["x", "y", "z"]
+        assert _similarity(a, a) == 1.0
+
+    def test_similarity_empty(self):
+        assert _similarity([], ["x"]) == 0.0
+
+    def test_fixture_detected(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "DuplicateCode" for s in smells)
+
+
+# ---------------------------------------------------------------------------
+# Rule 6 — Dead Code
+# ---------------------------------------------------------------------------
+
+class TestRuleDeadCode:
+    def test_no_call_graph_returns_empty(self):
+        tree = parse("def orphan(): pass\n")
+        smells = _rule_dead_code("f.py", tree, {})
+        assert smells == []
+
+    def test_called_function_not_flagged(self):
+        tree = parse("def used(): pass\n")
+        cg = {"callers": {"used": ["caller"]}, "callees": {"used": []}}
+        smells = _rule_dead_code("f.py", tree, cg)
+        assert smells == []
+
+    def test_uncalled_function_flagged(self):
+        tree = parse("def orphan(): pass\n")
+        cg = {"callers": {}, "callees": {"orphan": []}}
+        smells = _rule_dead_code("f.py", tree, cg)
+        assert any(s.smell_type == "DeadCode" for s in smells)
+
+    def test_dunder_methods_skipped(self):
+        tree = parse("def __init__(self): pass\n")
+        cg = {"callers": {}, "callees": {"__init__": []}}
+        smells = _rule_dead_code("f.py", tree, cg)
+        assert smells == []
+
+    def test_test_functions_skipped(self):
+        tree = parse("def test_something(): pass\n")
+        cg = {"callers": {}, "callees": {"test_something": []}}
+        smells = _rule_dead_code("f.py", tree, cg)
+        assert smells == []
+
+    def test_main_skipped(self):
+        tree = parse("def main(): pass\n")
+        cg = {"callers": {}, "callees": {"main": []}}
+        smells = _rule_dead_code("f.py", tree, cg)
+        assert smells == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 7 — Magic Numbers
+# ---------------------------------------------------------------------------
+
+class TestRuleMagicNumbers:
+    def test_whitelisted_values_skipped(self):
+        tree = parse("def f(x):\n    return x + 0 + 1 + 2\n")
+        smells = _rule_magic_numbers("f.py", tree)
+        assert smells == []
+
+    def test_arbitrary_literal_flagged(self):
+        tree = parse("def f(x):\n    return x * 42\n")
+        smells = _rule_magic_numbers("f.py", tree)
+        assert any(s.smell_type == "MagicNumber" for s in smells)
+
+    def test_module_level_constant_not_flagged(self):
+        # Module-level assignments are not inside functions — should not be flagged
+        tree = parse("LIMIT = 42\ndef f(x): return x\n")
+        smells = _rule_magic_numbers("f.py", tree)
+        assert smells == []
+
+    def test_fixture_detected(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "MagicNumber" for s in smells)
+
+    def test_string_not_flagged(self):
+        tree = parse("def f(): return 'hello'\n")
+        smells = _rule_magic_numbers("f.py", tree)
+        assert smells == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 8 — Deeply Nested
+# ---------------------------------------------------------------------------
+
+class TestRuleDeeplyNested:
+    def test_flat_func_no_smell(self):
+        tree = parse("def f(x):\n    if x:\n        return x\n    return 0\n")
+        smells = _rule_deeply_nested("f.py", tree)
+        assert smells == []
+
+    def test_depth_5_flagged(self):
+        src = """
+        def deep(data):
+            for a in data:
+                if a:
+                    for b in a:
+                        if b:
+                            for c in b:
+                                pass
+        """
+        tree = parse(src)
+        smells = _rule_deeply_nested("f.py", tree)
+        assert any(s.smell_type == "DeeplyNested" for s in smells)
+
+    def test_max_nesting_depth_trivial(self):
+        tree = parse("def f(): pass\n")
+        func = tree.body[0]
+        assert _max_nesting_depth(func) == 0
+
+    def test_max_nesting_depth_counted(self):
+        src = """
+        def f(x):
+            if x:
+                for i in x:
+                    if i:
+                        pass
+        """
+        func = parse(src).body[0]
+        depth = _max_nesting_depth(func)
+        assert depth == 3
+
+    def test_fixture_detected(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        assert any(s.smell_type == "DeeplyNested" for s in smells)
+
+
+# ---------------------------------------------------------------------------
+# SmellDetector — integration
+# ---------------------------------------------------------------------------
+
+class TestSmellDetectorIntegration:
+    def test_clean_module_no_smells(self, tmp_path):
+        src = """
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+        """
+        repo = make_repo(tmp_path, {"clean.py": src})
+        smells = SmellDetector(repo).detect()
+        # Clean module should produce few or no smells
+        assert all(s.smell_type not in {"LongFunction", "HighComplexity", "GodClass"} for s in smells)
+
+    def test_smelly_module_hits_all_rules(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        smell_types = {s.smell_type for s in smells}
+        # All rules except DeadCode (needs call graph) should fire on the fixture
+        assert "LongFunction" in smell_types
+        assert "HighComplexity" in smell_types
+        assert "GodClass" in smell_types
+        assert "LongParameterList" in smell_types
+        assert "DuplicateCode" in smell_types
+        assert "MagicNumber" in smell_types
+        assert "DeeplyNested" in smell_types
+
+    def test_dead_code_with_call_graph(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        cg = {"callers": {}, "callees": {"orphan_func": []}}
+        smells = SmellDetector(repo, call_graph=cg).detect()
+        assert any(s.smell_type == "DeadCode" for s in smells)
+
+    def test_skip_dirs_respected(self, tmp_path):
+        repo = make_repo(tmp_path, {"clean.py": "def f(): pass\n"})
+        venv = repo / ".venv" / "lib"
+        venv.mkdir(parents=True)
+        body = "\n".join(f"    x{i} = {i}" for i in range(110))
+        (venv / "hidden.py").write_text(f"def hidden():\n{body}\n")
+        smells = SmellDetector(repo).detect()
+        assert not any("hidden" in s.file for s in smells)
+
+    def test_syntax_error_file_skipped(self, tmp_path):
+        repo = make_repo(tmp_path, {
+            "good.py": "def f(): pass\n",
+            "broken.py": "def bad(\n  # syntax error",
+        })
+        smells = SmellDetector(repo).detect()
+        # Should not raise — broken file is silently skipped
+        assert not any("broken" in s.file for s in smells)
+
+    def test_results_sorted_errors_first(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        severities = [s.severity for s in smells]
+        sev_order = {"error": 0, "warning": 1, "info": 2}
+        assert severities == sorted(severities, key=lambda s: sev_order[s])
+
+    def test_self_analysis_does_not_crash(self):
+        root = Path(__file__).parent.parent
+        smells = SmellDetector(root).detect()
+        assert isinstance(smells, list)
+
+
+# ---------------------------------------------------------------------------
+# format_smells_for_prompt
+# ---------------------------------------------------------------------------
+
+class TestFormatSmellsForPrompt:
+    def test_empty_list(self):
+        result = format_smells_for_prompt([])
+        assert "No smells detected" in result
+
+    def test_includes_header(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        result = format_smells_for_prompt(smells)
+        assert "Code Smells" in result
+
+    def test_respects_max_smells(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        result = format_smells_for_prompt(smells, max_smells=3)
+        # Should mention truncation
+        lines_with_dash = [l for l in result.splitlines() if l.startswith("- ")]
+        assert len(lines_with_dash) <= 3
+
+    def test_shows_counts(self, tmp_path):
+        repo = make_repo(tmp_path, {"s.py": (FIXTURES / "smelly_module.py").read_text()})
+        smells = SmellDetector(repo).detect()
+        result = format_smells_for_prompt(smells)
+        assert "error" in result
+        assert "warning" in result
+
+
+# ---------------------------------------------------------------------------
+# GraphState integration
+# ---------------------------------------------------------------------------
+
+class TestGraphStateCodeSmells:
+    def test_code_smells_field_exists(self):
+        from app.core.state import GraphState
+        state = GraphState()
+        assert hasattr(state, "code_smells")
+        assert state.code_smells == []
+
+    def test_code_smells_accepts_list_of_dicts(self):
+        from app.core.state import GraphState
+        smell = CodeSmell(
+            file="x.py", line=10, smell_type="LongFunction",
+            severity="error", description="too long"
+        )
+        state = GraphState(code_smells=[smell.model_dump()])
+        assert len(state.code_smells) == 1
+        assert state.code_smells[0]["smell_type"] == "LongFunction"
+
+    def test_code_smells_serializes(self):
+        from app.core.state import GraphState
+        smell = CodeSmell(file="y.py", line=5, smell_type="MagicNumber",
+                          severity="info", description="magic 42")
+        state = GraphState(code_smells=[smell.model_dump()])
+        dumped = state.model_dump()
+        assert "code_smells" in dumped
+        assert dumped["code_smells"][0]["smell_type"] == "MagicNumber"


### PR DESCRIPTION
Rules implemented (all pure in-process AST analysis):
  1. LongFunction      — > 50 lines WARNING, > 100 lines ERROR
  2. HighComplexity    — cyclomatic complexity > 10 ERROR
  3. GodClass          — > 20 methods or > 500 lines ERROR
  4. LongParameterList — > 5 params WARNING (self/cls excluded)
  5. DuplicateCode     — >= 75% Jaccard similarity across function bodies WARNING
  6. DeadCode          — defined but never called (requires call graph) INFO
  7. MagicNumber       — numeric literals in function bodies (0,1,-1,2,100 whitelisted) INFO
  8. DeeplyNested      — nesting depth > 4 WARNING

- SmellDetector(repo_path, call_graph=None): runs all rules, returns sorted list
- CodeSmell model: file, line, smell_type, severity, description, suggestion
- sort_smells(): errors first, then warnings, then info
- format_smells_for_prompt(): compact prompt-ready summary
- Add code_smells: list[dict[str, Any]] to GraphState
- Wire into context_loader_node after dependency graph (best-effort)
- Pass call_graph to SmellDetector for dead-code detection
- Inject into planner prompt (top-10) and coder prompt (top-5)
- Add _format_code_smells_for_prompt() helper in nodes.py
- Add GET /api/code-smells endpoint (smells + counts by severity)
- tests/fixtures/smelly_module.py: intentional fixture triggering all 8 rules
- 55 new tests in tests/test_smell_detector.py — 423 total, 0 failures

Closes #14