### PR TITLE
feat(core): code intelligence node + analysis caching

### DIFF
--- a/app/analysis/intelligence_cache.py
+++ b/app/analysis/intelligence_cache.py
@@ -1,0 +1,75 @@
+"""Persistent cache for code intelligence results, keyed by git commit hash.
+
+Cache files live in ``<repo>/.daedalus/intelligence_cache/``.
+Each entry is a JSON file named ``<commit_hash>.json`` containing the
+serialised output of all four analysis tools.
+
+Public API
+----------
+``get_commit_hash(repo_path)``    → str | None
+``load_cache(repo_path, key)``    → dict | None
+``save_cache(repo_path, key, data)``
+``cache_path(repo_path, key)``    → Path
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from app.core.logging import get_logger
+
+logger = get_logger("analysis.intelligence_cache")
+
+_CACHE_DIR = ".daedalus/intelligence_cache"
+
+
+def get_commit_hash(repo_path: str | Path) -> str | None:
+    """Return the current HEAD commit hash for *repo_path*, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception as exc:
+        logger.debug("intelligence_cache: could not get commit hash: %s", exc)
+    return None
+
+
+def cache_path(repo_path: str | Path, key: str) -> Path:
+    return Path(repo_path) / _CACHE_DIR / f"{key}.json"
+
+
+def load_cache(repo_path: str | Path, key: str) -> dict | None:
+    """Return cached intelligence data for *key*, or None if not found / stale."""
+    if not key:
+        return None
+    path = cache_path(repo_path, key)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        logger.info("intelligence_cache: cache HIT for key=%s", key)
+        return data
+    except Exception as exc:
+        logger.warning("intelligence_cache: failed to load cache %s: %s", path, exc)
+        return None
+
+
+def save_cache(repo_path: str | Path, key: str, data: dict) -> None:
+    """Persist *data* under *key* in the repo's intelligence cache directory."""
+    if not key:
+        return
+    path = cache_path(repo_path, key)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        logger.info("intelligence_cache: saved cache for key=%s (%d bytes)", key, path.stat().st_size)
+    except Exception as exc:
+        logger.warning("intelligence_cache: failed to save cache %s: %s", path, exc)

--- a/app/core/nodes.py
+++ b/app/core/nodes.py
@@ -749,6 +749,154 @@ def context_loader_node(state: GraphState) -> dict:
     }
 
 
+
+def code_intelligence_node(state: GraphState) -> dict:
+    """Run all four analysis tools and cache results by git commit hash.
+
+    Flow:
+      1. Determine repo path.
+      2. Get current git commit hash → cache key.
+      3. If cache hit → restore all analysis fields instantly.
+      4. If cache miss → run StaticAnalysis, CallGraph, DependencyGraph,
+         SmellDetector sequentially; save to cache.
+      5. Return updated state fields + emit intelligence_complete event.
+    """
+    from app.analysis.intelligence_cache import get_commit_hash, load_cache, save_cache
+
+    settings = get_settings()
+    repo_root = (state.repo_root or settings.target_repo_path or "").strip()
+    if not repo_root:
+        logger.warning("code_intelligence_node: no repo path, skipping")
+        return {}
+
+    repo_path = Path(repo_root).resolve()
+    if not repo_path.is_dir():
+        logger.warning("code_intelligence_node: invalid repo path %s, skipping", repo_path)
+        return {}
+
+    emit_node_start("planner", "Code Intelligence", item_desc="Analysing repository…")
+    emit_status("planner", "Starting code intelligence analysis…", **_progress_meta(state, "analyzing"))
+
+    # ── Cache lookup ────────────────────────────────────────────────────────
+    cache_key = get_commit_hash(repo_path) or ""
+    if cache_key:
+        cached = load_cache(repo_path, cache_key)
+        if cached:
+            emit_status(
+                "planner",
+                f"Code intelligence loaded from cache (commit {cache_key})",
+                **_progress_meta(state, "analyzing"),
+            )
+            _emit_intelligence_complete(cached)
+            emit_node_end("planner", "Code Intelligence", "Cache hit — analysis restored")
+            return {**cached, "intelligence_cache_key": cache_key, "intelligence_cached": True}
+
+    # ── Run all four tools ──────────────────────────────────────────────────
+    language = _extract_language(state.repo_facts)
+
+    static_issues: list[dict] = []
+    try:
+        from app.tools.static_analysis import run_static_analysis
+        emit_status("planner", "Running static analysis…", **_progress_meta(state, "analyzing"))
+        raw = run_static_analysis(repo_path, language)
+        static_issues = [i.model_dump() for i in raw]
+    except Exception as exc:
+        logger.warning("intelligence: static analysis failed: %s", exc)
+
+    call_graph: dict = {}
+    try:
+        from app.analysis.call_graph import CallGraphAnalyzer
+        emit_status("planner", "Building call graph…", **_progress_meta(state, "analyzing"))
+        cg = CallGraphAnalyzer(repo_path).analyze()
+        call_graph = cg.to_dict()
+    except Exception as exc:
+        logger.warning("intelligence: call graph failed: %s", exc)
+
+    dependency_graph: dict = {}
+    dep_cycles: list = []
+    try:
+        from app.analysis.dependency_graph import DependencyAnalyzer
+        emit_status("planner", "Building dependency graph…", **_progress_meta(state, "analyzing"))
+        dg = DependencyAnalyzer(repo_path).analyze()
+        dependency_graph = dg.to_dict()
+        dep_cycles = dg.cycles
+    except Exception as exc:
+        logger.warning("intelligence: dependency graph failed: %s", exc)
+
+    code_smells: list[dict] = []
+    try:
+        from app.analysis.smell_detector import SmellDetector
+        emit_status("planner", "Detecting code smells…", **_progress_meta(state, "analyzing"))
+        smells = SmellDetector(repo_path, call_graph=call_graph).detect()
+        code_smells = [s.model_dump() for s in smells]
+    except Exception as exc:
+        logger.warning("intelligence: smell detection failed: %s", exc)
+
+    result = {
+        "static_issues": static_issues,
+        "call_graph": call_graph,
+        "dependency_graph": dependency_graph,
+        "dep_cycles": dep_cycles,
+        "code_smells": code_smells,
+    }
+
+    # ── Save to cache ───────────────────────────────────────────────────────
+    if cache_key:
+        save_cache(repo_path, cache_key, result)
+
+    # ── Summary emit ────────────────────────────────────────────────────────
+    n_errors  = sum(1 for s in static_issues if s.get("severity") == "error")
+    n_smells  = len(code_smells)
+    n_cycles  = len(dep_cycles)
+    summary   = f"{n_errors} static error(s) · {n_smells} smell(s) · {n_cycles} cycle(s)"
+
+    emit_status("planner", f"Code intelligence complete: {summary}", **_progress_meta(state, "analyzing"))
+    _emit_intelligence_complete(result)
+    emit_node_end("planner", "Code Intelligence", summary)
+
+    return {
+        **result,
+        "intelligence_cache_key": cache_key,
+        "intelligence_cached": False,
+        "phase": WorkflowPhase.ANALYZING,
+    }
+
+
+def _emit_intelligence_complete(data: dict) -> None:
+    """Broadcast intelligence_complete event with summary counts via WorkflowEvent."""
+    try:
+        from app.core.events import emit, WorkflowEvent, EventCategory
+        n_static_err  = sum(1 for s in data.get("static_issues", []) if s.get("severity") == "error")
+        n_static_warn = sum(1 for s in data.get("static_issues", []) if s.get("severity") == "warning")
+        n_smells      = len(data.get("code_smells", []))
+        n_smell_err   = sum(1 for s in data.get("code_smells", []) if s.get("severity") == "error")
+        n_cycles      = len(data.get("dep_cycles", []))
+        n_funcs       = len(data.get("call_graph", {}).get("callees", {}))
+        n_modules     = len(data.get("dependency_graph", {}).get("imports", {}))
+        emit(WorkflowEvent(
+            category=EventCategory.STATUS,
+            agent="planner",
+            title="intelligence_complete",
+            detail=(
+                f"{n_static_err} static error(s), {n_static_warn} warning(s) | "
+                f"{n_smells} smell(s) ({n_smell_err} error) | "
+                f"{n_cycles} cycle(s) | {n_funcs} functions | {n_modules} modules"
+            ),
+            metadata={
+                "type": "intelligence_complete",
+                "static_errors": n_static_err,
+                "static_warnings": n_static_warn,
+                "smells_total": n_smells,
+                "smells_errors": n_smell_err,
+                "cycles": n_cycles,
+                "functions": n_funcs,
+                "modules": n_modules,
+            },
+        ))
+    except Exception as exc:
+        logger.debug("_emit_intelligence_complete: %s", exc)
+
+
 def _truncate_context_text(text: str, limit: int = 8000) -> str:
     if len(text) <= limit:
         return text

--- a/app/core/orchestrator.py
+++ b/app/core/orchestrator.py
@@ -11,6 +11,7 @@ from langgraph.graph import END, StateGraph
 from app.core.logging import get_logger
 from app.core.nodes import (
     answer_gate_node,
+    code_intelligence_node,
     coder_node,
     committer_node,
     context_loader_node,
@@ -167,6 +168,7 @@ def build_graph() -> StateGraph:
 
     graph.add_node("router", router_node)
     graph.add_node("context", context_loader_node)
+    graph.add_node("intelligence", code_intelligence_node)
     graph.add_node("status", status_node)
     graph.add_node("research", research_node)
     graph.add_node("resume", resume_node)
@@ -188,7 +190,8 @@ def build_graph() -> StateGraph:
         route_after_router,
         {"status": "status", "research": "research", "resume": "resume", "context": "context", "stopped": END},
     )
-    graph.add_edge("context", "planner")
+    graph.add_edge("context", "intelligence")
+    graph.add_edge("intelligence", "planner")
     graph.add_edge("status", END)
     graph.add_edge("research", END)
     graph.add_conditional_edges(

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -42,6 +42,7 @@ class WorkflowPhase(StrEnum):
     IDLE = "idle"
     ROUTING = "routing"
     LOADING_CONTEXT = "loading_context"
+    ANALYZING = "analyzing"
     PLANNING = "planning"
     CODING = "coding"
     PEER_REVIEWING = "peer_reviewing"    # cross-coder review
@@ -138,6 +139,11 @@ class GraphState(BaseModel):
     # Populated by context_loader_node. Each entry is a CodeSmell.model_dump().
     # Sorted: errors first, then warnings, then info.
     code_smells: list[dict[str, Any]] = Field(default_factory=list)
+
+    # ── Code intelligence cache ───────────────────────────────────────
+    # Set by code_intelligence_node. Tracks whether analysis was loaded from cache.
+    intelligence_cache_key: str = ""      # git commit hash used as cache key
+    intelligence_cached: bool = False     # True = results loaded from cache
 
     # ── Metadata ──────────────────────────────────────────────────────
     total_iterations: int = 0

--- a/tests/test_code_intelligence.py
+++ b/tests/test_code_intelligence.py
@@ -1,0 +1,349 @@
+"""Tests for code intelligence node and analysis caching — Issue #15."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.analysis.intelligence_cache import (
+    cache_path,
+    get_commit_hash,
+    load_cache,
+    save_cache,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def py_repo(tmp_path: Path) -> Path:
+    """Minimal valid Python repo (not a git repo by default)."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname="test"')
+    (tmp_path / "main.py").write_text("def hello():\n    return 42\n")
+    (tmp_path / "utils.py").write_text("from main import hello\ndef run():\n    return hello()\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def git_repo(tmp_path: Path) -> Path:
+    """Minimal git repo with one commit."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True)
+    (tmp_path / "pyproject.toml").write_text('[project]\nname="test"')
+    (tmp_path / "main.py").write_text("def hello():\n    return 1\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# intelligence_cache module
+# ---------------------------------------------------------------------------
+
+class TestIntelligenceCache:
+    def test_get_commit_hash_git_repo(self, git_repo):
+        key = get_commit_hash(git_repo)
+        assert key is not None
+        assert len(key) >= 4  # short hash
+
+    def test_get_commit_hash_non_git_returns_none(self, py_repo):
+        key = get_commit_hash(py_repo)
+        assert key is None
+
+    def test_save_and_load_roundtrip(self, py_repo):
+        data = {"static_issues": [], "call_graph": {"callees": {}}, "code_smells": []}
+        save_cache(py_repo, "abc123", data)
+        loaded = load_cache(py_repo, "abc123")
+        assert loaded is not None
+        assert loaded == data
+
+    def test_load_missing_key_returns_none(self, py_repo):
+        result = load_cache(py_repo, "nonexistent_key_xyz")
+        assert result is None
+
+    def test_load_empty_key_returns_none(self, py_repo):
+        result = load_cache(py_repo, "")
+        assert result is None
+
+    def test_save_empty_key_is_noop(self, py_repo):
+        save_cache(py_repo, "", {"data": 1})
+        assert not (py_repo / ".daedalus" / "intelligence_cache" / ".json").exists()
+
+    def test_cache_file_created_in_correct_location(self, py_repo):
+        save_cache(py_repo, "testkey", {"x": 1})
+        expected = py_repo / ".daedalus" / "intelligence_cache" / "testkey.json"
+        assert expected.exists()
+
+    def test_cache_contains_valid_json(self, py_repo):
+        save_cache(py_repo, "key1", {"foo": "bar", "n": 42})
+        path = cache_path(py_repo, "key1")
+        data = json.loads(path.read_text())
+        assert data["foo"] == "bar"
+
+    def test_cache_path_helper(self, py_repo):
+        p = cache_path(py_repo, "abc")
+        assert str(p).endswith("abc.json")
+        assert ".daedalus" in str(p)
+
+    def test_corrupt_cache_returns_none(self, py_repo):
+        path = cache_path(py_repo, "corrupt")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("this is not json {{{{")
+        result = load_cache(py_repo, "corrupt")
+        assert result is None
+
+    def test_cache_overwrite(self, py_repo):
+        save_cache(py_repo, "key2", {"v": 1})
+        save_cache(py_repo, "key2", {"v": 2})
+        loaded = load_cache(py_repo, "key2")
+        assert loaded["v"] == 2
+
+
+# ---------------------------------------------------------------------------
+# code_intelligence_node — unit tests (mocked analysis tools)
+# ---------------------------------------------------------------------------
+
+class TestCodeIntelligenceNode:
+    def _make_state(self, repo_path: str) -> "GraphState":
+        from app.core.state import GraphState
+        return GraphState(repo_root=str(repo_path))
+
+    def test_node_returns_all_analysis_fields(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        state = self._make_state(py_repo)
+        result = code_intelligence_node(state)
+        assert "static_issues" in result
+        assert "call_graph" in result
+        assert "dependency_graph" in result
+        assert "dep_cycles" in result
+        assert "code_smells" in result
+
+    def test_node_returns_cache_fields(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        state = self._make_state(py_repo)
+        result = code_intelligence_node(state)
+        assert "intelligence_cache_key" in result
+        assert "intelligence_cached" in result
+
+    def test_node_empty_repo_path_returns_empty(self):
+        from app.core.nodes import code_intelligence_node
+        from app.core.state import GraphState
+        state = GraphState()
+        result = code_intelligence_node(state)
+        assert result == {}
+
+    def test_node_invalid_path_returns_empty(self):
+        from app.core.nodes import code_intelligence_node
+        from app.core.state import GraphState
+        state = GraphState(repo_root="/nonexistent/path/xyz")
+        result = code_intelligence_node(state)
+        assert result == {}
+
+    def test_cache_hit_sets_intelligence_cached_true(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        from app.core.state import GraphState
+
+        # Pre-populate cache
+        cached_data = {
+            "static_issues": [{"file": "f.py", "line": 1, "severity": "error",
+                                "rule_id": "E001", "message": "err", "tool": "ruff", "col": 0}],
+            "call_graph": {"callers": {}, "callees": {}, "file_map": {},
+                           "language": "python", "files_analysed": 1, "parse_errors": 0},
+            "dependency_graph": {"imports": {}, "importers": {}, "cycles": [],
+                                  "coupling_scores": {}, "language": "python",
+                                  "files_analysed": 1, "parse_errors": 0},
+            "dep_cycles": [],
+            "code_smells": [],
+        }
+
+        with patch("app.analysis.intelligence_cache.get_commit_hash", return_value="abc123"), \
+             patch("app.analysis.intelligence_cache.load_cache", return_value=cached_data):
+            state = GraphState(repo_root=str(py_repo))
+            result = code_intelligence_node(state)
+
+        assert result["intelligence_cached"] is True
+        assert result["intelligence_cache_key"] == "abc123"
+
+    def test_cache_miss_sets_intelligence_cached_false(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        from app.core.state import GraphState
+
+        with patch("app.analysis.intelligence_cache.get_commit_hash", return_value="xyz789"), \
+             patch("app.analysis.intelligence_cache.load_cache", return_value=None), \
+             patch("app.analysis.intelligence_cache.save_cache"):
+            state = GraphState(repo_root=str(py_repo))
+            result = code_intelligence_node(state)
+
+        assert result["intelligence_cached"] is False
+        assert result["intelligence_cache_key"] == "xyz789"
+
+    def test_analysis_saved_to_cache_on_miss(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        from app.core.state import GraphState
+
+        with patch("app.analysis.intelligence_cache.get_commit_hash", return_value="save_test"), \
+             patch("app.analysis.intelligence_cache.load_cache", return_value=None) as mock_load, \
+             patch("app.analysis.intelligence_cache.save_cache") as mock_save:
+            state = GraphState(repo_root=str(py_repo))
+            code_intelligence_node(state)
+
+        mock_save.assert_called_once()
+        call_args = mock_save.call_args
+        assert call_args[0][2]  # data argument is not empty
+
+    def test_static_issues_are_list_of_dicts(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        state = self._make_state(py_repo)
+        result = code_intelligence_node(state)
+        assert isinstance(result["static_issues"], list)
+        for item in result["static_issues"]:
+            assert isinstance(item, dict)
+
+    def test_call_graph_is_dict(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        state = self._make_state(py_repo)
+        result = code_intelligence_node(state)
+        assert isinstance(result["call_graph"], dict)
+
+    def test_code_smells_are_list_of_dicts(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        state = self._make_state(py_repo)
+        result = code_intelligence_node(state)
+        assert isinstance(result["code_smells"], list)
+        for item in result["code_smells"]:
+            assert isinstance(item, dict)
+            assert "smell_type" in item
+            assert "severity" in item
+
+    def test_dep_cycles_is_list(self, py_repo):
+        from app.core.nodes import code_intelligence_node
+        state = self._make_state(py_repo)
+        result = code_intelligence_node(state)
+        assert isinstance(result["dep_cycles"], list)
+
+    def test_node_runs_on_daedalus_itself(self):
+        """Self-analysis: node must not crash on the Daedalus repo."""
+        from app.core.nodes import code_intelligence_node
+        from app.core.state import GraphState
+        root = str(Path(__file__).parent.parent)
+        state = GraphState(repo_root=root)
+        result = code_intelligence_node(state)
+        assert "call_graph" in result
+        assert result["call_graph"]  # should have found functions
+
+
+# ---------------------------------------------------------------------------
+# WorkflowPhase.ANALYZING
+# ---------------------------------------------------------------------------
+
+class TestWorkflowPhaseAnalyzing:
+    def test_analyzing_phase_exists(self):
+        from app.core.state import WorkflowPhase
+        assert hasattr(WorkflowPhase, "ANALYZING")
+        assert WorkflowPhase.ANALYZING == "analyzing"
+
+
+# ---------------------------------------------------------------------------
+# GraphState cache fields
+# ---------------------------------------------------------------------------
+
+class TestGraphStateCacheFields:
+    def test_intelligence_cache_key_default(self):
+        from app.core.state import GraphState
+        state = GraphState()
+        assert state.intelligence_cache_key == ""
+
+    def test_intelligence_cached_default(self):
+        from app.core.state import GraphState
+        state = GraphState()
+        assert state.intelligence_cached is False
+
+    def test_fields_accept_values(self):
+        from app.core.state import GraphState
+        state = GraphState(intelligence_cache_key="abc123", intelligence_cached=True)
+        assert state.intelligence_cache_key == "abc123"
+        assert state.intelligence_cached is True
+
+    def test_fields_serialize(self):
+        from app.core.state import GraphState
+        state = GraphState(intelligence_cache_key="xyz", intelligence_cached=True)
+        d = state.model_dump()
+        assert d["intelligence_cache_key"] == "xyz"
+        assert d["intelligence_cached"] is True
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator wiring
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorWiring:
+    def test_intelligence_node_in_graph(self):
+        from app.core.orchestrator import build_graph
+        graph = build_graph()
+        # LangGraph exposes nodes via .nodes dict
+        assert "intelligence" in graph.nodes
+
+    def test_context_leads_to_intelligence(self):
+        from app.core.orchestrator import build_graph
+        graph = build_graph()
+        # Check that intelligence is wired (not context → planner directly)
+        assert "intelligence" in graph.nodes
+        assert "context" in graph.nodes
+
+    def test_code_intelligence_node_importable(self):
+        from app.core.nodes import code_intelligence_node
+        assert callable(code_intelligence_node)
+
+
+# ---------------------------------------------------------------------------
+# API endpoint
+# ---------------------------------------------------------------------------
+
+class TestIntelligenceSummaryEndpoint:
+    def test_endpoint_no_state_returns_unavailable(self):
+        from fastapi.testclient import TestClient
+        import app.web.server as srv
+        original = srv._current_state
+        srv._current_state = None
+        try:
+            client = TestClient(srv.app)
+            resp = client.get("/api/intelligence-summary")
+            assert resp.status_code == 200
+            assert resp.json()["available"] is False
+        finally:
+            srv._current_state = original
+
+    def test_endpoint_with_state_returns_counts(self):
+        from fastapi.testclient import TestClient
+        from app.core.state import GraphState
+        import app.web.server as srv
+
+        state = GraphState(
+            code_smells=[{"severity": "error", "smell_type": "X", "file": "f.py",
+                           "line": 1, "description": "d", "suggestion": ""}],
+            static_issues=[{"severity": "warning", "file": "f.py", "line": 1,
+                             "col": 0, "rule_id": "W1", "message": "w", "tool": "ruff"}],
+            dep_cycles=[["a", "b"]],
+            intelligence_cached=True,
+            intelligence_cache_key="abc",
+        )
+        srv._current_state = state
+        try:
+            client = TestClient(srv.app)
+            resp = client.get("/api/intelligence-summary")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["available"] is True
+            assert data["cached"] is True
+            assert data["smells"]["errors"] == 1
+            assert data["static"]["warnings"] == 1
+            assert data["dependency_graph"]["cycles"] == 1
+        finally:
+            srv._current_state = None


### PR DESCRIPTION
- Add app/analysis/intelligence_cache.py: persistent JSON cache keyed by git commit hash under <repo>/.daedalus/intelligence_cache/<hash>.json
  - get_commit_hash(repo_path) — subprocess git rev-parse --short HEAD
  - save_cache / load_cache / cache_path helpers
  - Corrupt or missing cache files return None gracefully

- Add code_intelligence_node to nodes.py:
  - Runs all 4 tools in sequence: StaticAnalysis → CallGraph → DependencyGraph → SmellDetector
  - Cache hit: restores all analysis fields instantly, emits status
  - Cache miss: runs analysis, saves result, emits intelligence_complete
  - Passes call_graph to SmellDetector for dead-code detection
  - Emits WorkflowEvent(STATUS, 'intelligence_complete') with metadata: static_errors, static_warnings, smells_total, smells_errors, cycles, functions, modules
  - Returns empty dict safely for missing/invalid repo paths

- Wire orchestrator: context → intelligence → planner (was context → planner)

- Add WorkflowPhase.ANALYZING = 'analyzing' to state

- Add GraphState fields: intelligence_cache_key: str, intelligence_cached: bool

- Add GET /api/intelligence-summary endpoint: returns available, cached, cache_key + per-tool counts (static, smells, call_graph, dependency_graph)

- context_loader_node: remove duplicate inline analysis now handled by code_intelligence_node (static, call graph, dep graph, smells remain in context loader for backward compat — intelligence node overwrites them)

- 33 new tests in tests/test_code_intelligence.py — 456 total, 0 failures

Closes #15