### PR TITLE
feat(prompts+ui): agent prompt enrichment + intelligence web dashboard

### DIFF
--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -295,6 +295,117 @@
   }
   .btn-answer:hover { opacity: 0.85; }
   .btn-answer:disabled { opacity: 0.4; cursor: default; }
+
+  /* ── Intel button ─────────────────────── */
+  .intel-btn {
+    padding: 4px 12px; border-radius: 6px; border: 1px solid var(--border-light);
+    background: var(--surface2); color: var(--accent); font-family: var(--font);
+    font-size: 11px; font-weight: 700; cursor: pointer; transition: background 0.15s;
+    letter-spacing: 0.5px;
+  }
+  .intel-btn:hover { background: var(--surface3); }
+  .intel-btn.active { background: var(--accent-dim); border-color: var(--accent); }
+
+  /* ── Intelligence Panel ───────────────── */
+  .intel-panel {
+    position: fixed; top: 0; right: 0; bottom: 0; width: 380px; max-width: 100vw;
+    background: var(--surface); border-left: 1px solid var(--border);
+    display: flex; flex-direction: column; z-index: 100; overflow: hidden;
+    box-shadow: -4px 0 24px rgba(0,0,0,0.4);
+    animation: slide-in-right 0.2s ease;
+  }
+  @keyframes slide-in-right {
+    from { transform: translateX(100%); opacity: 0; }
+    to   { transform: translateX(0);   opacity: 1; }
+  }
+  .intel-header {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 14px; background: var(--surface2);
+    border-bottom: 1px solid var(--border); flex-shrink: 0;
+  }
+  .intel-title { flex: 1; font-size: 11px; font-weight: 700; color: var(--accent); letter-spacing: 1.5px; }
+  .intel-cache-badge {
+    font-size: 9px; padding: 2px 7px; border-radius: 8px;
+    background: var(--surface3); color: var(--text-dim); font-weight: 700;
+  }
+  .intel-refresh, .intel-close {
+    background: none; border: none; color: var(--text-dim); cursor: pointer;
+    font-size: 14px; padding: 2px 5px; border-radius: 4px; transition: color 0.15s;
+    font-family: var(--font);
+  }
+  .intel-refresh:hover, .intel-close:hover { color: var(--text); }
+  .intel-body { flex: 1; overflow-y: auto; padding: 12px 14px; display: flex; flex-direction: column; gap: 12px; }
+  .intel-body::-webkit-scrollbar { width: 4px; }
+  .intel-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+  .intel-loading { color: var(--text-dim); font-size: 12px; padding: 20px 0; text-align: center; }
+  .intel-empty { color: var(--text-faint); font-size: 11px; text-align: center; padding: 40px 0; }
+
+  /* Intel sections */
+  .intel-section { border-radius: 6px; overflow: hidden; border: 1px solid var(--border); }
+  .intel-section-hdr {
+    display: flex; align-items: center; gap: 8px;
+    padding: 7px 12px; background: var(--surface2);
+    font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+    cursor: pointer; user-select: none;
+  }
+  .intel-section-hdr:hover { background: var(--surface3); }
+  .intel-section-hdr .s-icon { font-size: 13px; }
+  .intel-section-hdr .s-title { flex: 1; }
+  .intel-section-hdr .s-count {
+    padding: 1px 7px; border-radius: 8px; font-size: 9px; font-weight: 800;
+  }
+  .s-count-error { background: var(--red-dim); color: var(--red); }
+  .s-count-warning { background: var(--yellow-dim); color: var(--yellow); }
+  .s-count-ok { background: var(--green-dim); color: var(--green); }
+  .s-count-info { background: var(--surface3); color: var(--text-dim); }
+  .intel-section-body { padding: 8px 0; }
+  .intel-section.collapsed .intel-section-body { display: none; }
+
+  /* Intel rows */
+  .intel-row {
+    display: flex; align-items: flex-start; gap: 8px;
+    padding: 5px 12px; font-size: 11.5px; line-height: 1.5; border-bottom: 1px solid var(--border);
+  }
+  .intel-row:last-child { border-bottom: none; }
+  .intel-row .r-sev {
+    font-size: 9px; font-weight: 800; padding: 1px 5px; border-radius: 3px; flex-shrink: 0; margin-top: 2px;
+  }
+  .r-sev-error { background: var(--red-dim); color: var(--red); }
+  .r-sev-warning { background: var(--yellow-dim); color: var(--yellow); }
+  .r-sev-info { background: var(--surface3); color: var(--text-dim); }
+  .intel-row .r-text { flex: 1; color: var(--text); }
+  .intel-row .r-loc { color: var(--text-faint); font-size: 10px; }
+
+  /* Summary cards */
+  .intel-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; padding: 8px 12px; }
+  .intel-card {
+    border-radius: 5px; padding: 8px 10px; background: var(--surface2);
+    border: 1px solid var(--border);
+  }
+  .intel-card .c-label { font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.8px; }
+  .intel-card .c-value { font-size: 20px; font-weight: 700; color: var(--text); margin-top: 2px; }
+  .intel-card .c-sub { font-size: 9px; color: var(--text-dim); margin-top: 1px; }
+  .intel-card.c-err .c-value { color: var(--red); }
+  .intel-card.c-warn .c-value { color: var(--yellow); }
+  .intel-card.c-ok .c-value { color: var(--green); }
+  .intel-card.c-info .c-value { color: var(--accent); }
+
+  /* Cycle paths */
+  .cycle-path {
+    padding: 5px 12px; font-size: 11px; color: var(--red);
+    border-bottom: 1px solid var(--border); word-break: break-all;
+  }
+  .cycle-path:last-child { border-bottom: none; }
+
+  /* Coupling rows */
+  .coupling-row {
+    display: flex; align-items: center; gap: 8px; padding: 5px 12px;
+    font-size: 11px; border-bottom: 1px solid var(--border);
+  }
+  .coupling-row:last-child { border-bottom: none; }
+  .coupling-bar-bg { flex: 1; height: 4px; background: var(--surface3); border-radius: 2px; }
+  .coupling-bar { height: 4px; border-radius: 2px; background: var(--accent); }
+  .coupling-score { font-size: 10px; color: var(--text-dim); width: 32px; text-align: right; }
 </style>
 </head>
 <body>
@@ -303,6 +414,7 @@
   <div class="header-status">
     <span class="progress-text" id="progressText">—</span>
     <span class="badge badge-idle" id="badge">IDLE</span>
+    <button class="intel-btn" id="intelBtn" onclick="toggleIntel()" title="Code Intelligence Dashboard">🧠 Intel</button>
   </div>
 </header>
 
@@ -313,6 +425,19 @@
   <div class="input-row">
     <input type="text" id="taskInput" placeholder="Describe a coding task…" autocomplete="off" />
     <button onclick="sendTask()">SEND</button>
+  </div>
+</div>
+
+<!-- Intelligence Dashboard Panel -->
+<div class="intel-panel" id="intelPanel" style="display:none">
+  <div class="intel-header">
+    <span class="intel-title">🧠 CODE INTELLIGENCE</span>
+    <span class="intel-cache-badge" id="intelCacheBadge"></span>
+    <button class="intel-refresh" onclick="loadIntelligence()" title="Refresh">↻</button>
+    <button class="intel-close" onclick="toggleIntel()" title="Close">✕</button>
+  </div>
+  <div class="intel-body" id="intelBody">
+    <div class="intel-loading">Loading intelligence data…</div>
   </div>
 </div>
 
@@ -675,6 +800,10 @@ function handleEvent(evt) {
           total: metadata.items_total,
           branch: metadata.branch || '',
         });
+        // Detect intelligence_complete event metadata
+        if (metadata.type === 'intelligence_complete') {
+          _onIntelligenceComplete();
+        }
       }
       break;
 
@@ -823,6 +952,179 @@ function sendTask() {
       .then(r => r.json()).then(d => addStatus(`✓ Task queued`))
       .catch(e => addStatus(`❌ Failed: ${e}`, 'status-error'));
   }
+}
+
+
+// ── Intelligence Dashboard ────────────────
+let _intelVisible = false;
+
+function toggleIntel() {
+  _intelVisible = !_intelVisible;
+  const panel = document.getElementById('intelPanel');
+  const btn   = document.getElementById('intelBtn');
+  panel.style.display = _intelVisible ? 'flex' : 'none';
+  btn.classList.toggle('active', _intelVisible);
+  if (_intelVisible) loadIntelligence();
+}
+
+async function loadIntelligence() {
+  const body = document.getElementById('intelBody');
+  const cacheBadge = document.getElementById('intelCacheBadge');
+  body.innerHTML = '<div class="intel-loading">Loading…</div>';
+
+  try {
+    const [summary, smells, depGraph] = await Promise.all([
+      fetch('/api/intelligence-summary').then(r => r.json()),
+      fetch('/api/code-smells').then(r => r.json()),
+      fetch('/api/dependency-graph').then(r => r.json()),
+    ]);
+
+    if (!summary.available) {
+      body.innerHTML = '<div class="intel-empty">No intelligence data available yet.<br>Start a task to analyse the repository.</div>';
+      cacheBadge.textContent = '';
+      return;
+    }
+
+    cacheBadge.textContent = summary.cached ? `CACHED @ ${summary.cache_key || '?'}` : 'LIVE';
+
+    const sections = [];
+
+    // ── Overview cards ─────────────────────────────────────────────
+    const staticErr  = summary.static?.errors  || 0;
+    const staticWarn = summary.static?.warnings || 0;
+    const smellErr   = summary.smells?.errors   || 0;
+    const smellWarn  = summary.smells?.warnings || 0;
+    const cycles     = summary.dependency_graph?.cycles || 0;
+    const funcs      = summary.call_graph?.functions || 0;
+
+    sections.push(`
+      <div class="intel-section">
+        <div class="intel-section-hdr" onclick="toggleSection(this)">
+          <span class="s-icon">📊</span><span class="s-title">Overview</span>
+        </div>
+        <div class="intel-section-body">
+          <div class="intel-cards">
+            <div class="intel-card ${staticErr > 0 ? 'c-err' : 'c-ok'}">
+              <div class="c-label">Static Errors</div>
+              <div class="c-value">${staticErr}</div>
+              <div class="c-sub">${staticWarn} warning(s)</div>
+            </div>
+            <div class="intel-card ${smellErr > 0 ? 'c-err' : smellWarn > 0 ? 'c-warn' : 'c-ok'}">
+              <div class="c-label">Code Smells</div>
+              <div class="c-value">${summary.smells?.total || 0}</div>
+              <div class="c-sub">${smellErr} error(s), ${smellWarn} warning(s)</div>
+            </div>
+            <div class="intel-card ${cycles > 0 ? 'c-err' : 'c-ok'}">
+              <div class="c-label">Dep Cycles</div>
+              <div class="c-value">${cycles}</div>
+              <div class="c-sub">${summary.dependency_graph?.modules || 0} modules</div>
+            </div>
+            <div class="intel-card c-info">
+              <div class="c-label">Functions</div>
+              <div class="c-value">${funcs}</div>
+              <div class="c-sub">${summary.call_graph?.edges || 0} call edges</div>
+            </div>
+          </div>
+        </div>
+      </div>`);
+
+    // ── Circular imports ────────────────────────────────────────────
+    const cycleList = depGraph.cycles || [];
+    if (cycleList.length > 0) {
+      const rows = cycleList.slice(0, 10).map(cycle =>
+        `<div class="cycle-path">⭮ ${esc(cycle.join(' → '))} → ${esc(cycle[0])}</div>`
+      ).join('');
+      const more = cycleList.length > 10
+        ? `<div class="cycle-path" style="color:var(--text-dim)">… and ${cycleList.length - 10} more</div>` : '';
+      sections.push(`
+        <div class="intel-section">
+          <div class="intel-section-hdr" onclick="toggleSection(this)">
+            <span class="s-icon">⭮</span><span class="s-title">Circular Imports</span>
+            <span class="s-count s-count-error">${cycleList.length}</span>
+          </div>
+          <div class="intel-section-body">${rows}${more}</div>
+        </div>`);
+    }
+
+    // ── Most-coupled modules ────────────────────────────────────────
+    const depJson = depGraph.json || {};
+    const couplingScores = depJson.coupling_scores || {};
+    const topCoupled = Object.entries(couplingScores)
+      .sort((a, b) => b[1] - a[1]).slice(0, 8);
+    if (topCoupled.length > 0) {
+      const rows = topCoupled.map(([mod, score]) => {
+        const pct = Math.round(score * 100);
+        return `
+          <div class="coupling-row">
+            <span style="flex:1;color:var(--text);font-size:11px;word-break:break-all">${esc(mod)}</span>
+            <div class="coupling-bar-bg"><div class="coupling-bar" style="width:${pct}%"></div></div>
+            <span class="coupling-score">${pct}%</span>
+          </div>`;
+      }).join('');
+      sections.push(`
+        <div class="intel-section">
+          <div class="intel-section-hdr" onclick="toggleSection(this)">
+            <span class="s-icon">🔗</span><span class="s-title">Most Coupled Modules</span>
+          </div>
+          <div class="intel-section-body">${rows}</div>
+        </div>`);
+    }
+
+    // ── Code smells ─────────────────────────────────────────────────
+    const allSmells = smells.smells || [];
+    if (allSmells.length > 0) {
+      const shown = allSmells.slice(0, 20);
+      const rows = shown.map(s => {
+        const sevClass = s.severity === 'error' ? 'r-sev-error'
+                       : s.severity === 'warning' ? 'r-sev-warning' : 'r-sev-info';
+        return `
+          <div class="intel-row">
+            <span class="r-sev ${sevClass}">${s.severity.toUpperCase()}</span>
+            <span class="r-text">
+              <strong>${esc(s.smell_type)}</strong> — ${esc(s.description)}
+              ${s.suggestion ? `<br><span style="color:var(--text-dim);font-size:10.5px">💡 ${esc(s.suggestion)}</span>` : ''}
+            </span>
+            <span class="r-loc">${esc(s.file)}:${s.line}</span>
+          </div>`;
+      }).join('');
+      const more = allSmells.length > 20
+        ? `<div class="intel-row" style="color:var(--text-faint)">… and ${allSmells.length - 20} more</div>` : '';
+      const errCount  = smells.errors   || 0;
+      const warnCount = smells.warnings || 0;
+      const countClass = errCount > 0 ? 's-count-error' : warnCount > 0 ? 's-count-warning' : 's-count-ok';
+      sections.push(`
+        <div class="intel-section">
+          <div class="intel-section-hdr" onclick="toggleSection(this)">
+            <span class="s-icon">🔍</span><span class="s-title">Code Smells</span>
+            <span class="s-count ${countClass}">${allSmells.length}</span>
+          </div>
+          <div class="intel-section-body">${rows}${more}</div>
+        </div>`);
+    }
+
+    body.innerHTML = sections.join('') || '<div class="intel-empty">All clear — no issues detected.</div>';
+
+  } catch (err) {
+    body.innerHTML = `<div class="intel-empty">Failed to load intelligence data.<br><small style="color:var(--text-faint)">${esc(String(err))}</small></div>`;
+    console.error('intel load error:', err);
+  }
+}
+
+function toggleSection(hdr) {
+  hdr.closest('.intel-section').classList.toggle('collapsed');
+}
+
+// Auto-refresh intel panel on intelligence_complete event
+function _onIntelligenceComplete() {
+  if (_intelVisible) loadIntelligence();
+  // Flash the button to signal new data
+  const btn = document.getElementById('intelBtn');
+  btn.style.background = 'var(--green-dim)';
+  btn.style.color = 'var(--green)';
+  setTimeout(() => {
+    btn.style.background = '';
+    btn.style.color = '';
+  }, 2000);
 }
 
 input.addEventListener('keydown', (e) => { if (e.key === 'Enter') sendTask(); });

--- a/tests/test_prompt_enrichment.py
+++ b/tests/test_prompt_enrichment.py
@@ -1,0 +1,356 @@
+"""Tests for Issue #16 — agent prompt enrichment and intelligence web UI dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_SMELLS = [
+    {"file": "a.py", "line": 10, "smell_type": "LongFunction", "severity": "error",
+     "description": "too long", "suggestion": "split it"},
+    {"file": "b.py", "line": 5,  "smell_type": "MagicNumber",  "severity": "info",
+     "description": "magic 42", "suggestion": "use constant"},
+    {"file": "c.py", "line": 2,  "smell_type": "GodClass",     "severity": "error",
+     "description": "too big",  "suggestion": "split class"},
+]
+SAMPLE_STATIC = [
+    {"file": "a.py", "line": 3, "col": 0, "severity": "error", "rule_id": "E001",
+     "message": "unused import", "tool": "ruff"},
+    {"file": "b.py", "line": 7, "col": 0, "severity": "warning", "rule_id": "W001",
+     "message": "line too long", "tool": "ruff"},
+]
+SAMPLE_CALL_GRAPH = {
+    "callers": {"foo": ["main"]}, "callees": {"main": ["foo"], "foo": []},
+    "file_map": {}, "language": "python", "files_analysed": 2, "parse_errors": 0,
+}
+SAMPLE_DEP_GRAPH = {
+    "imports": {"a": ["b"], "b": []}, "importers": {"b": ["a"]},
+    "cycles": [["x", "y"]], "coupling_scores": {"a": 0.5, "b": 0.3},
+    "language": "python", "files_analysed": 2, "parse_errors": 0,
+}
+
+
+def _make_state(**kwargs):
+    from app.core.state import GraphState
+    defaults = dict(
+        code_smells=SAMPLE_SMELLS,
+        static_issues=SAMPLE_STATIC,
+        call_graph=SAMPLE_CALL_GRAPH,
+        dependency_graph=SAMPLE_DEP_GRAPH,
+        dep_cycles=[["x", "y"]],
+        intelligence_cached=False,
+        intelligence_cache_key="",
+    )
+    defaults.update(kwargs)
+    return GraphState(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _format_intelligence_summary_for_prompt  (planner / coder — full)
+# ---------------------------------------------------------------------------
+
+class TestFormatIntelligenceSummaryFull:
+    def test_returns_string(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        state = _make_state()
+        result = _format_intelligence_summary_for_prompt(state)
+        assert isinstance(result, str)
+
+    def test_includes_header(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        state = _make_state()
+        assert "Code Intelligence Summary" in _format_intelligence_summary_for_prompt(state)
+
+    def test_includes_smells_section(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        state = _make_state()
+        result = _format_intelligence_summary_for_prompt(state)
+        assert "Code Smell" in result or "Smell" in result
+
+    def test_includes_static_section(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        state = _make_state()
+        assert "static" in _format_intelligence_summary_for_prompt(state).lower()
+
+    def test_includes_dep_graph(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        state = _make_state()
+        result = _format_intelligence_summary_for_prompt(state)
+        assert "Dependency" in result or "cycle" in result.lower() or "coupled" in result.lower()
+
+    def test_empty_state_returns_empty_string(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        from app.core.state import GraphState
+        state = GraphState()
+        result = _format_intelligence_summary_for_prompt(state)
+        assert result == ""
+
+    def test_cached_note_shown_when_cached(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        state = _make_state(intelligence_cached=True, intelligence_cache_key="abc123")
+        result = _format_intelligence_summary_for_prompt(state)
+        assert "abc123" in result or "cached" in result.lower()
+
+    def test_no_cached_note_when_not_cached(self):
+        from app.core.nodes import _format_intelligence_summary_for_prompt
+        state = _make_state(intelligence_cached=False, intelligence_cache_key="")
+        result = _format_intelligence_summary_for_prompt(state)
+        assert "cached" not in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _format_intelligence_summary_reviewer  (reduced budget)
+# ---------------------------------------------------------------------------
+
+class TestFormatIntelligenceSummaryReviewer:
+    def test_returns_string(self):
+        from app.core.nodes import _format_intelligence_summary_reviewer
+        state = _make_state()
+        assert isinstance(_format_intelligence_summary_reviewer(state), str)
+
+    def test_empty_state_returns_empty(self):
+        from app.core.nodes import _format_intelligence_summary_reviewer
+        from app.core.state import GraphState
+        assert _format_intelligence_summary_reviewer(GraphState()) == ""
+
+    def test_includes_smells(self):
+        from app.core.nodes import _format_intelligence_summary_reviewer
+        state = _make_state()
+        assert "Smell" in _format_intelligence_summary_reviewer(state) or \
+               "smell" in _format_intelligence_summary_reviewer(state).lower()
+
+    def test_includes_header(self):
+        from app.core.nodes import _format_intelligence_summary_reviewer
+        state = _make_state()
+        assert "Code Intelligence Summary" in _format_intelligence_summary_reviewer(state)
+
+
+# ---------------------------------------------------------------------------
+# _format_intelligence_summary_tester  (minimal — smells errors + static)
+# ---------------------------------------------------------------------------
+
+class TestFormatIntelligenceSummaryTester:
+    def test_returns_string(self):
+        from app.core.nodes import _format_intelligence_summary_tester
+        state = _make_state()
+        assert isinstance(_format_intelligence_summary_tester(state), str)
+
+    def test_empty_state_returns_empty(self):
+        from app.core.nodes import _format_intelligence_summary_tester
+        from app.core.state import GraphState
+        assert _format_intelligence_summary_tester(GraphState()) == ""
+
+    def test_includes_static_issues(self):
+        from app.core.nodes import _format_intelligence_summary_tester
+        state = _make_state()
+        result = _format_intelligence_summary_tester(state)
+        assert "static" in result.lower() or "ruff" in result.lower() or "E001" in result
+
+    def test_includes_only_error_smells(self):
+        from app.core.nodes import _format_intelligence_summary_tester
+        # Only error-level smells, not info
+        state = _make_state()
+        result = _format_intelligence_summary_tester(state)
+        # Should include LongFunction (error) and GodClass (error) but not MagicNumber (info)
+        if "MagicNumber" in result:
+            # info-level smell should not appear in tester context
+            assert False, "Tester prompt should not include info-level smells"
+
+    def test_no_call_graph_in_tester(self):
+        from app.core.nodes import _format_intelligence_summary_tester
+        state = _make_state()
+        result = _format_intelligence_summary_tester(state)
+        # Call graph is excluded from tester (minimal budget)
+        assert "most-called" not in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Peer review node — intelligence injected
+# ---------------------------------------------------------------------------
+
+class TestPeerReviewNodeIntelligence:
+    def _invoke_patch(self, *args, **kwargs):
+        return "APPROVE\n**Verdict**: APPROVE\nSuggested commit: feat: add X"
+
+    def test_peer_review_builds_intelligence_context(self):
+        """peer_review_node must call _format_intelligence_summary_reviewer."""
+        from app.core.nodes import _format_intelligence_summary_reviewer
+        state = _make_state()
+        result = _format_intelligence_summary_reviewer(state)
+        assert result  # non-empty for a state with smells and static issues
+
+    def test_intelligence_ctx_replaces_call_graph_ctx(self):
+        """Verify old call_graph_ctx variable is gone, replaced by intelligence_ctx."""
+        import inspect, app.core.nodes as n
+        src = inspect.getsource(n.peer_review_node)
+        assert "intelligence_ctx" in src
+        assert "call_graph_ctx" not in src
+
+
+# ---------------------------------------------------------------------------
+# Tester node — intelligence injected
+# ---------------------------------------------------------------------------
+
+class TestTesterNodeIntelligence:
+    def test_tester_node_builds_tester_intelligence(self):
+        from app.core.nodes import _format_intelligence_summary_tester
+        state = _make_state()
+        result = _format_intelligence_summary_tester(state)
+        assert isinstance(result, str)
+
+    def test_tester_node_uses_intelligence_ctx(self):
+        """Verify tester_node calls _format_intelligence_summary_tester."""
+        import inspect, app.core.nodes as n
+        src = inspect.getsource(n.tester_node)
+        assert "intelligence_ctx" in src
+        assert "_format_intelligence_summary_tester" in src
+
+
+# ---------------------------------------------------------------------------
+# Planner node — consolidated helper replaces 4 separate blocks
+# ---------------------------------------------------------------------------
+
+class TestPlannerNodeConsolidatedPrompt:
+    def test_planner_uses_consolidated_helper(self):
+        import inspect, app.core.nodes as n
+        src = inspect.getsource(n.planner_plan_node)
+        assert "_format_intelligence_summary_for_prompt" in src
+
+    def test_planner_no_separate_smell_injection(self):
+        """The old 4-line pattern should be gone from planner."""
+        import inspect, app.core.nodes as n
+        src = inspect.getsource(n.planner_plan_node)
+        # Old separate injections replaced by consolidated helper
+        assert "_format_code_smells_for_prompt(state.code_smells" not in src
+
+
+# ---------------------------------------------------------------------------
+# Web UI HTML — dashboard elements present
+# ---------------------------------------------------------------------------
+
+class TestWebUIDashboard:
+    @pytest.fixture()
+    def html(self) -> str:
+        return (Path(__file__).parent.parent / "app" / "web" / "static" / "index.html").read_text()
+
+    def test_intel_button_present(self, html):
+        assert "intelBtn" in html
+        assert "Intel" in html
+
+    def test_intel_panel_present(self, html):
+        assert "intelPanel" in html
+        assert "intel-panel" in html
+
+    def test_toggle_intel_function_present(self, html):
+        assert "function toggleIntel" in html
+
+    def test_load_intelligence_function_present(self, html):
+        assert "function loadIntelligence" in html
+
+    def test_on_intelligence_complete_function_present(self, html):
+        assert "_onIntelligenceComplete" in html
+
+    def test_calls_intelligence_summary_endpoint(self, html):
+        assert "/api/intelligence-summary" in html
+
+    def test_calls_code_smells_endpoint(self, html):
+        assert "/api/code-smells" in html
+
+    def test_calls_dependency_graph_endpoint(self, html):
+        assert "/api/dependency-graph" in html
+
+    def test_coupling_bar_rendered(self, html):
+        assert "coupling-bar" in html
+
+    def test_cycle_path_element_present(self, html):
+        assert "cycle-path" in html
+
+    def test_intel_cards_grid_present(self, html):
+        assert "intel-cards" in html
+
+    def test_toggle_section_function_present(self, html):
+        assert "function toggleSection" in html
+
+    def test_intelligence_complete_event_handled(self, html):
+        assert "intelligence_complete" in html
+
+
+# ---------------------------------------------------------------------------
+# API endpoints integration
+# ---------------------------------------------------------------------------
+
+class TestAPIEndpoints:
+    def _client(self):
+        from fastapi.testclient import TestClient
+        import app.web.server as srv
+        return TestClient(srv.app), srv
+
+    def test_intelligence_summary_no_state(self):
+        client, srv = self._client()
+        original = srv._current_state
+        srv._current_state = None
+        try:
+            resp = client.get("/api/intelligence-summary")
+            assert resp.status_code == 200
+            assert resp.json()["available"] is False
+        finally:
+            srv._current_state = original
+
+    def test_intelligence_summary_with_state(self):
+        client, srv = self._client()
+        from app.core.state import GraphState
+        state = GraphState(
+            code_smells=SAMPLE_SMELLS,
+            static_issues=SAMPLE_STATIC,
+            dep_cycles=[["a", "b"]],
+            intelligence_cached=True,
+            intelligence_cache_key="test123",
+        )
+        srv._current_state = state
+        try:
+            resp = client.get("/api/intelligence-summary")
+            data = resp.json()
+            assert data["available"] is True
+            assert data["cached"] is True
+            assert data["cache_key"] == "test123"
+            assert data["smells"]["total"] == 3
+            assert data["smells"]["errors"] == 2
+            assert data["static"]["errors"] == 1
+            assert data["dependency_graph"]["cycles"] == 1
+        finally:
+            srv._current_state = None
+
+    def test_code_smells_endpoint(self):
+        client, srv = self._client()
+        from app.core.state import GraphState
+        srv._current_state = GraphState(code_smells=SAMPLE_SMELLS)
+        try:
+            resp = client.get("/api/code-smells")
+            data = resp.json()
+            assert data["total"] == 3
+            assert data["errors"] == 2
+            assert data["infos"] == 1
+        finally:
+            srv._current_state = None
+
+    def test_dependency_graph_endpoint(self):
+        client, srv = self._client()
+        from app.core.state import GraphState
+        srv._current_state = GraphState(
+            dependency_graph=SAMPLE_DEP_GRAPH,
+            dep_cycles=[["x", "y"]],
+        )
+        try:
+            resp = client.get("/api/dependency-graph")
+            data = resp.json()
+            assert "mermaid" in data
+            assert data["cycles"] == [["x", "y"]]
+        finally:
+            srv._current_state = None


### PR DESCRIPTION
## Prompt Enrichment (nodes.py)

- Add _format_intelligence_summary_for_prompt(state) — consolidated block combining static analysis, call graph, dependency graph, and code smells into a single '## Code Intelligence Summary' section. Replaces 4 separate per-tool injections in planner and coder prompts.

- Add _format_intelligence_summary_reviewer(state) — reduced budget variant (max_smells=5, max_issues=5, cg=5, dg=3) for peer review prompts.

- Add _format_intelligence_summary_tester(state) — minimal variant for tester: static issues + error-only smells (no call graph, no dep graph).

- peer_review_node: replace call_graph_ctx with intelligence_ctx using _format_intelligence_summary_reviewer — reviewer now sees cycles, coupling scores, and smells in addition to call graph info.

- tester_node: inject _format_intelligence_summary_tester into prompt so tester is aware of existing static errors before running tests.

- planner_plan_node / coder_node: replace 4 separate format blocks with single consolidated _format_intelligence_summary_for_prompt call.

- Cache note shown in summary header when intelligence_cached=True: '## Code Intelligence Summary (cached @ abc123)'

## Web UI Intelligence Dashboard (index.html)

- Add '🧠 Intel' button to header; toggles slide-in side panel (380px wide)
- Panel fetches /api/intelligence-summary, /api/code-smells, /api/dependency-graph in parallel on open
- Overview section: 4 stat cards (Static Errors, Code Smells, Dep Cycles, Functions) with colour-coded severity (red=errors, yellow=warnings, green=all-clear)
- Circular Imports section: lists all detected cycles as 'a → b → c → a' paths
- Most Coupled Modules section: horizontal bar chart per module (coupling score 0–100%)
- Code Smells section: severity badge + description + suggestion + file:line for each finding (max 20 shown, remainder indicated)
- All sections are collapsible via click on section header
- Panel auto-refreshes when 'intelligence_complete' WebSocket event fires (metadata.type check); Intel button flashes green for 2s to signal update
- Cache badge in panel header shows 'CACHED @ <hash>' or 'LIVE'
- CSS: intel-panel, intel-section, intel-cards, coupling-bar, cycle-path — all themed to match existing dark mono design

- 40 new tests in tests/test_prompt_enrichment.py — 496 total, 0 failures

Closes #16