### PR TITLE
feat(core): documenter agent — implement node + wire into orchestrator

### DIFF
--- a/app/agents/prompts/documenter.txt
+++ b/app/agents/prompts/documenter.txt
@@ -1,20 +1,67 @@
-You are the Documentation Agent.
+You are the Documentation Agent for an autonomous coding system.
 
-Your job is to implement documentation-focused TODO items with minimal, accurate changes.
+Your job is to update project documentation after a code commit. You receive the git diff
+of the last commit and must update only the documentation that is provably affected.
 
-Rules:
-- Work only on docs-related files unless the task explicitly requires code comments.
-- Keep language precise and actionable.
-- Keep structure consistent with existing docs.
-- If API behavior is described, verify it against source code before editing.
-- Do not invent endpoints, commands, or config variables.
-- Mention assumptions when information is missing.
+## Core rules
 
-Execution environment:
-- The runtime is Windows.
-- Shell commands are executed via PowerShell.
+- Only document what the diff proves. Never invent endpoints, config variables, classes,
+  or behaviours that are not present in the diff or existing source.
+- Do not leave TODO, FIXME, or placeholder text in any file you write.
+- Keep changes minimal and consistent with the existing document style.
+- Verify API behaviour against the source code before describing it.
+- If information is ambiguous or missing, note it explicitly in your output summary.
 
-Output requirements:
-- Summarize what was updated and why.
-- List changed files.
-- Note anything that still needs human confirmation.
+## What to update
+
+### CHANGELOG.md (always)
+- Add a new entry under `## [Unreleased]` (create the section if absent).
+- Follow the Keep a Changelog format: https://keepachangelog.com
+- Use subsections: Added, Changed, Fixed, Removed. Only include non-empty subsections.
+- One bullet per logical change. Keep bullets concise (≤ 120 chars each).
+- Do NOT create a version header — leave the entry under [Unreleased].
+- If CHANGELOG.md does not exist, create it with the standard header.
+
+### README.md (only if the diff adds/changes public-facing behaviour)
+Triggers: new API endpoints, new CLI flags, new environment variables, new config keys,
+changed command syntax, new installation steps.
+- Edit only the affected section. Do not rewrite sections that are unaffected.
+- Match the heading level and style of existing sections.
+
+### Inline docstrings (only for new public functions/classes without a docstring)
+- Add a one-line docstring to each new def/class that has none.
+- Do not modify existing docstrings.
+
+### API documentation (if docs/api.md or similar exists and diff adds endpoints)
+- Add the new endpoint with method, path, request body, response schema.
+- Mirror the format of existing endpoint entries exactly.
+
+## What NOT to update
+- Internal private functions (prefixed with _).
+- Files not mentioned or implied by the diff.
+- Test files, configuration files, lock files.
+- Comments inside code (unless part of the task description).
+
+## Execution environment
+
+Use the available tools to:
+1. Read the diff with: git_command("git diff HEAD~1 HEAD")
+2. Read existing doc files before editing them.
+3. Write updated files with write_file.
+4. Verify source behaviour with read_file when needed.
+
+## Output format
+
+After completing your changes, output a structured summary:
+
+CHANGED FILES:
+- <path>: <one-line reason>
+
+CHANGELOG ENTRY:
+<paste the exact text you added to CHANGELOG.md>
+
+SKIPPED:
+<any doc that was triggered but skipped, with reason>
+
+ASSUMPTIONS:
+<any information you could not verify and had to assume>

--- a/app/core/nodes.py
+++ b/app/core/nodes.py
@@ -2452,3 +2452,94 @@ def committer_node(state: GraphState) -> dict:
             "pending_approval": {},
             "stop_reason": "",
         }
+
+# ---------------------------------------------------------------------------
+# Documenter Node
+# ---------------------------------------------------------------------------
+
+# Patterns in a git diff that indicate documentation should be updated.
+# Matched against the raw diff text (additions + context lines).
+_DOCS_TRIGGER_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^\+\s*def [a-z]", re.MULTILINE),         # new public function
+    re.compile(r"^\+\s*async def [a-z]", re.MULTILINE),   # new public async function
+    re.compile(r"^\+\s*class [A-Z]", re.MULTILINE),        # new public class
+    re.compile(r"^\+.*@(app|router)\.(get|post|put|delete|patch|head)\b", re.MULTILINE),  # new API endpoint
+    re.compile(r"^\+.*settings\.\w+\s*=", re.MULTILINE),  # new settings assignment
+    re.compile(r"^\+\s*[A-Z_]{3,}\s*=\s*", re.MULTILINE), # new constant / env var
+    re.compile(r"^\+.*argparse\|add_argument", re.MULTILINE),  # new CLI arg
+]
+
+
+def _diff_needs_docs(diff: str) -> bool:
+    """Return True if the git diff contains documentation-worthy changes.
+
+    Uses lightweight regex heuristics so no LLM call is made for trivial
+    commits (test-only changes, typo fixes, pure refactors).
+    """
+    return any(pat.search(diff) for pat in _DOCS_TRIGGER_PATTERNS)
+
+
+def documenter_node(state: GraphState) -> dict:
+    """Update project documentation after a successful commit.
+
+    Runs after every commit. Uses a heuristic diff scan to decide whether
+    an LLM call is warranted. If the diff contains no documentation-worthy
+    changes the node exits immediately without an LLM call.
+
+    The documenter writes documentation changes to disk but does NOT commit
+    them — they will be picked up by the next commit cycle or can be
+    committed manually.
+    """
+    emit_node_start("documenter", "Documenting", item_desc="Checking diff for documentation updates")
+    emit_status(
+        "documenter",
+        "📝 Documenter: scanning commit diff…",
+        **_progress_meta(state, "documenting"),
+    )
+
+    # -- 1. Get diff of the last commit -----------------------------------
+    try:
+        diff = git_command.invoke({"command": "git diff HEAD~1 HEAD"})
+    except Exception as exc:
+        logger.warning("documenter | git diff failed: %s", exc)
+        diff = ""
+
+    if not diff:
+        emit_node_end("documenter", "Documenting", "No diff available — skipping documentation update")
+        return {}
+
+    # -- 2. Heuristic gate — skip LLM if diff is not doc-worthy ----------
+    if not _diff_needs_docs(diff):
+        emit_status(
+            "documenter",
+            "📝 Documenter: no documentation-worthy changes detected — skipping",
+            **_progress_meta(state, "documenting"),
+        )
+        emit_node_end("documenter", "Documenting", "Skipped — diff contains no public API or config changes")
+        return {}
+
+    # -- 3. LLM call with full diff context ------------------------------
+    emit_status(
+        "documenter",
+        "📝 Documenter: documentation-worthy changes detected — updating docs…",
+        **_progress_meta(state, "documenting"),
+    )
+
+    prompt = (
+        "## Documentation Task\n\n"
+        "A commit was just made. Review the diff below and update the project documentation "
+        "following your system instructions.\n\n"
+        f"### Git Diff (last commit)\n\n```diff\n{diff[:8000]}\n```\n\n"
+        "Start by reading any existing CHANGELOG.md and README.md with the available tools, "
+        "then make the necessary updates. Output your structured summary when done."
+    )
+
+    result = _invoke_agent(
+        "documenter",
+        [HumanMessage(content=prompt)],
+        DOCUMENTER_TOOLS,
+        inject_memory=False,
+    )
+
+    emit_node_end("documenter", "Documenting", result[:400] if result else "Documentation updated")
+    return {}

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -52,6 +52,7 @@ class WorkflowPhase(StrEnum):
     WAITING_FOR_APPROVAL = "waiting_for_approval"
     WAITING_FOR_ANSWER = "waiting_for_answer"
     COMMITTING = "committing"
+    DOCUMENTING = "documenting"
     COMPLETE = "complete"
     STOPPED = "stopped"
 

--- a/tests/test_documenter.py
+++ b/tests/test_documenter.py
@@ -1,0 +1,335 @@
+"""Tests for the Documenter Agent node (Issue #28).
+
+Covers:
+- WorkflowPhase.DOCUMENTING presence
+- _diff_needs_docs heuristic (true/false for various diffs)
+- documenter_node: no-op path (no diff, uninteresting diff)
+- documenter_node: LLM call path (documentation-worthy diff)
+- Orchestrator wiring: _route_after_commit → documenter
+- Orchestrator wiring: _route_after_documenter → coder | complete
+- Graph contains documenter node
+- documenter.txt prompt completeness
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.core.state import GraphState, WorkflowPhase
+
+
+# ---------------------------------------------------------------------------
+# 1. WorkflowPhase.DOCUMENTING
+# ---------------------------------------------------------------------------
+
+class TestWorkflowPhaseDocumenting:
+    def test_documenting_in_enum(self):
+        assert hasattr(WorkflowPhase, "DOCUMENTING")
+        assert WorkflowPhase.DOCUMENTING == "documenting"
+
+    def test_documenting_is_str(self):
+        assert isinstance(WorkflowPhase.DOCUMENTING, str)
+
+
+# ---------------------------------------------------------------------------
+# 2. _diff_needs_docs heuristic
+# ---------------------------------------------------------------------------
+
+class TestDiffNeedsDocs:
+    def _check(self, diff: str) -> bool:
+        from app.core.nodes import _diff_needs_docs
+        return _diff_needs_docs(diff)
+
+    def test_new_public_function_triggers(self):
+        diff = "+def calculate_total(items: list) -> float:\n"
+        assert self._check(diff) is True
+
+    def test_new_async_function_triggers(self):
+        diff = "+async def fetch_data(url: str):\n"
+        assert self._check(diff) is True
+
+    def test_new_public_class_triggers(self):
+        diff = "+class TokenBudget:\n"
+        assert self._check(diff) is True
+
+    def test_new_api_endpoint_triggers(self):
+        diff = '+@app.get("/api/health")\n'
+        assert self._check(diff) is True
+
+    def test_new_router_endpoint_triggers(self):
+        diff = '+@router.post("/api/tasks")\n'
+        assert self._check(diff) is True
+
+    def test_new_constant_triggers(self):
+        diff = "+MAX_RETRIES = 5\n"
+        assert self._check(diff) is True
+
+    def test_private_function_does_not_trigger(self):
+        diff = "+def _internal_helper():\n"
+        assert self._check(diff) is False
+
+    def test_test_only_change_does_not_trigger(self):
+        diff = "+    assert result == 42\n+    mock.assert_called_once()\n"
+        assert self._check(diff) is False
+
+    def test_empty_diff_does_not_trigger(self):
+        assert self._check("") is False
+
+    def test_comment_only_change_does_not_trigger(self):
+        diff = "+# Fix typo in variable name\n"
+        assert self._check(diff) is False
+
+    def test_multiline_diff_with_trigger(self):
+        diff = (
+            " context line\n"
+            "+def process_batch(items):\n"
+            "+    return [x * 2 for x in items]\n"
+        )
+        assert self._check(diff) is True
+
+    def test_deletion_only_does_not_trigger(self):
+        # Lines starting with '-' are removals — we only look at additions '+'
+        diff = "-def old_function():\n-    pass\n"
+        assert self._check(diff) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. documenter_node — no-op paths
+# ---------------------------------------------------------------------------
+
+class TestDocumenterNodeNoOp:
+    def _run_node(self, diff_output: str) -> dict:
+        from app.core.nodes import documenter_node
+        from app.core.events import clear_listeners
+
+        state = GraphState(phase=WorkflowPhase.CODING)
+
+        with patch("app.core.nodes.git_command") as mock_git, \
+             patch("app.core.nodes._invoke_agent") as mock_llm:
+            mock_git.invoke.return_value = diff_output
+            result = documenter_node(state)
+            clear_listeners()
+
+        return result, mock_llm
+
+    def test_empty_diff_returns_empty_dict(self):
+        result, mock_llm = self._run_node("")
+        assert result == {}
+        mock_llm.assert_not_called()
+
+    def test_non_doc_diff_no_llm_call(self):
+        diff = "+    assert x == 1\n+    mock.reset_mock()\n"
+        result, mock_llm = self._run_node(diff)
+        assert result == {}
+        mock_llm.assert_not_called()
+
+    def test_git_command_failure_returns_empty(self):
+        from app.core.nodes import documenter_node
+        from app.core.events import clear_listeners
+
+        state = GraphState(phase=WorkflowPhase.CODING)
+        with patch("app.core.nodes.git_command") as mock_git, \
+             patch("app.core.nodes._invoke_agent") as mock_llm:
+            mock_git.invoke.side_effect = RuntimeError("git error")
+            result = documenter_node(state)
+            clear_listeners()
+
+        assert result == {}
+        mock_llm.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. documenter_node — LLM call path
+# ---------------------------------------------------------------------------
+
+class TestDocumenterNodeLLMPath:
+    def test_doc_worthy_diff_calls_llm(self):
+        from app.core.nodes import documenter_node
+        from app.core.events import clear_listeners
+
+        diff = "+def new_public_api(x: int) -> str:\n+    return str(x)\n"
+        state = GraphState(phase=WorkflowPhase.CODING)
+
+        with patch("app.core.nodes.git_command") as mock_git, \
+             patch("app.core.nodes._invoke_agent") as mock_llm:
+            mock_git.invoke.return_value = diff
+            mock_llm.return_value = "CHANGED FILES:\n- CHANGELOG.md: added entry\n"
+            result = documenter_node(state)
+            clear_listeners()
+
+        mock_llm.assert_called_once()
+        assert result == {}  # documenter never mutates state
+
+    def test_llm_called_with_documenter_role(self):
+        from app.core.nodes import documenter_node
+        from app.core.events import clear_listeners
+
+        diff = "+class NewFeature:\n+    pass\n"
+        state = GraphState(phase=WorkflowPhase.CODING)
+
+        with patch("app.core.nodes.git_command") as mock_git, \
+             patch("app.core.nodes._invoke_agent") as mock_llm:
+            mock_git.invoke.return_value = diff
+            mock_llm.return_value = "done"
+            documenter_node(state)
+            clear_listeners()
+
+        call_args = mock_llm.call_args
+        assert call_args[0][0] == "documenter"
+
+    def test_llm_called_with_documenter_tools(self):
+        from app.core.nodes import documenter_node, DOCUMENTER_TOOLS
+        from app.core.events import clear_listeners
+
+        diff = "+@app.get('/health')\n+def health():\n+    return {'ok': True}\n"
+        state = GraphState(phase=WorkflowPhase.CODING)
+
+        with patch("app.core.nodes.git_command") as mock_git, \
+             patch("app.core.nodes._invoke_agent") as mock_llm:
+            mock_git.invoke.return_value = diff
+            mock_llm.return_value = "done"
+            documenter_node(state)
+            clear_listeners()
+
+        call_kwargs = mock_llm.call_args[0]
+        # Third positional arg is tools
+        assert call_kwargs[2] == DOCUMENTER_TOOLS
+
+    def test_diff_truncated_to_8000_chars(self):
+        from app.core.nodes import documenter_node
+        from app.core.events import clear_listeners
+
+        # Create a diff that's longer than 8000 chars but triggers docs
+        long_diff = "+def new_func():\n" + ("+    x = 1\n" * 900)
+        state = GraphState(phase=WorkflowPhase.CODING)
+
+        with patch("app.core.nodes.git_command") as mock_git, \
+             patch("app.core.nodes._invoke_agent") as mock_llm:
+            mock_git.invoke.return_value = long_diff
+            mock_llm.return_value = "done"
+            documenter_node(state)
+            clear_listeners()
+
+        # The prompt passed to _invoke_agent should have truncated diff
+        call_args = mock_llm.call_args
+        messages = call_args[0][1]
+        prompt_content = messages[0].content
+        # 8000 chars for diff + surrounding text — total prompt < 10000
+        assert len(prompt_content) < 10000
+
+    def test_documenter_does_not_mutate_phase(self):
+        """documenter_node must return {} — it never changes phase or state."""
+        from app.core.nodes import documenter_node
+        from app.core.events import clear_listeners
+
+        diff = "+def public_fn():\n    pass\n"
+        state = GraphState(phase=WorkflowPhase.CODING)
+
+        with patch("app.core.nodes.git_command") as mock_git, \
+             patch("app.core.nodes._invoke_agent") as mock_llm:
+            mock_git.invoke.return_value = diff
+            mock_llm.return_value = "done"
+            result = documenter_node(state)
+            clear_listeners()
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# 5. Orchestrator routing
+# ---------------------------------------------------------------------------
+
+class TestDocumenterOrchestration:
+    @pytest.fixture(autouse=True)
+    def _reset_shutdown(self):
+        """Ensure the global shutdown event is clear before and after each test."""
+        from app.core.orchestrator import reset_shutdown
+        reset_shutdown()
+        yield
+        reset_shutdown()
+
+    def test_commit_routes_to_documenter_when_more_items(self):
+        from app.core.orchestrator import _route_after_commit
+        state = GraphState(phase=WorkflowPhase.CODING)
+        assert _route_after_commit(state) == "documenter"
+
+    def test_commit_routes_to_complete_when_done(self):
+        from app.core.orchestrator import _route_after_commit
+        state = GraphState(phase=WorkflowPhase.COMPLETE)
+        assert _route_after_commit(state) == "complete"
+
+    def test_documenter_routes_to_coder_when_more_items(self):
+        from app.core.orchestrator import _route_after_documenter
+        state = GraphState(phase=WorkflowPhase.CODING)
+        assert _route_after_documenter(state) == "coder"
+
+    def test_documenter_routes_to_complete_when_done(self):
+        from app.core.orchestrator import _route_after_documenter
+        state = GraphState(phase=WorkflowPhase.COMPLETE)
+        assert _route_after_documenter(state) == "complete"
+
+    def test_documenter_routes_to_stopped_on_shutdown(self):
+        from app.core.orchestrator import _route_after_documenter, reset_shutdown, request_shutdown
+        reset_shutdown()
+        request_shutdown()
+        try:
+            state = GraphState(phase=WorkflowPhase.CODING)
+            assert _route_after_documenter(state) == "stopped"
+        finally:
+            reset_shutdown()
+
+    def test_graph_contains_documenter_node(self):
+        from app.core.orchestrator import build_graph
+        graph = build_graph()
+        assert "documenter" in graph.nodes
+
+    def test_graph_compiles_with_documenter(self):
+        from app.core.orchestrator import compile_graph
+        compiled = compile_graph()
+        assert compiled is not None
+
+    def test_resume_routes_to_documenter_when_documenting(self):
+        from app.core.orchestrator import _route_after_resume
+        state = GraphState(phase=WorkflowPhase.DOCUMENTING)
+        assert _route_after_resume(state) == "documenter"
+
+
+# ---------------------------------------------------------------------------
+# 6. Prompt file completeness
+# ---------------------------------------------------------------------------
+
+class TestDocumenterPrompt:
+    @pytest.fixture
+    def prompt_text(self) -> str:
+        prompt_path = Path(__file__).parent.parent / "app" / "agents" / "prompts" / "documenter.txt"
+        return prompt_path.read_text()
+
+    def test_prompt_file_exists(self):
+        prompt_path = Path(__file__).parent.parent / "app" / "agents" / "prompts" / "documenter.txt"
+        assert prompt_path.exists()
+
+    def test_prompt_mentions_changelog(self, prompt_text):
+        assert "CHANGELOG" in prompt_text
+
+    def test_prompt_mentions_keep_a_changelog(self, prompt_text):
+        assert "Keep a Changelog" in prompt_text or "keepachangelog" in prompt_text.lower()
+
+    def test_prompt_mentions_readme(self, prompt_text):
+        assert "README" in prompt_text
+
+    def test_prompt_mentions_unreleased(self, prompt_text):
+        assert "Unreleased" in prompt_text or "unreleased" in prompt_text.lower()
+
+    def test_prompt_forbids_invention(self, prompt_text):
+        # Should explicitly warn against inventing things
+        assert "invent" in prompt_text.lower() or "do not invent" in prompt_text.lower()
+
+    def test_prompt_has_output_format(self, prompt_text):
+        assert "CHANGED FILES" in prompt_text or "Output format" in prompt_text
+
+    def test_prompt_longer_than_original(self, prompt_text):
+        # Original was ~200 chars — new prompt should be substantially richer
+        assert len(prompt_text) > 800

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -150,13 +150,24 @@ class TestRouting:
 
     def test_route_after_commit_more_items(self):
         from app.core.orchestrator import _route_after_commit
+        # commit always routes to documenter first; documenter then routes to coder or complete
         state = GraphState(phase=WorkflowPhase.CODING)
-        assert _route_after_commit(state) == "coder"
+        assert _route_after_commit(state) == "documenter"
 
     def test_route_after_commit_complete(self):
         from app.core.orchestrator import _route_after_commit
         state = GraphState(phase=WorkflowPhase.COMPLETE)
         assert _route_after_commit(state) == "complete"
+
+    def test_route_after_documenter_more_items(self):
+        from app.core.orchestrator import _route_after_documenter
+        state = GraphState(phase=WorkflowPhase.CODING)
+        assert _route_after_documenter(state) == "coder"
+
+    def test_route_after_documenter_complete(self):
+        from app.core.orchestrator import _route_after_documenter
+        state = GraphState(phase=WorkflowPhase.COMPLETE)
+        assert _route_after_documenter(state) == "complete"
 
 
 class TestGraphBuild:


### PR DESCRIPTION
- Add WorkflowPhase.DOCUMENTING to state.py
- Add _DOCS_TRIGGER_PATTERNS (7 compiled regexes) and _diff_needs_docs() to nodes.py: lightweight heuristic gate — skips LLM call for commits that touch only tests, comments, or private code (lines not starting with +def [a-z], +class [A-Z], @app.get, new constants, etc.)
- Add documenter_node() to nodes.py:
  - Reads 'git diff HEAD~1 HEAD' after every commit
  - Returns {} immediately if diff is empty or heuristic returns False
  - Truncates diff to 8000 chars before sending to LLM
  - Calls _invoke_agent('documenter', ..., DOCUMENTER_TOOLS) for documentation-worthy diffs
  - Never mutates GraphState phase — returns {} always
  - Emits node_start, status, node_end events for Web UI visibility
- Wire orchestrator: commit → documenter → (coder | complete | stopped)
  - _route_after_commit() now always returns 'documenter' (was 'coder')
  - New _route_after_documenter() routes to coder/complete/stopped
  - documenter node added to build_graph()
  - _route_after_resume() handles WorkflowPhase.DOCUMENTING for crash recovery
- Rewrite app/agents/prompts/documenter.txt from 7 lines to a full production prompt: CHANGELOG.md rules (Keep a Changelog), README.md triggers, inline docstring policy, API doc policy, explicit 'do not invent' constraint, structured output format (CHANGED FILES / CHANGELOG ENTRY / SKIPPED / ASSUMPTIONS)
- Update tests/test_orchestrator.py: fix test_route_after_commit_more_items (now expects 'documenter'), add test_route_after_documenter_* variants
- Add tests/test_documenter.py: 38 tests covering WorkflowPhase, _diff_needs_docs (12 cases: true/false paths), documenter_node no-op paths (empty diff, boring diff, git failure), LLM call path (role, tools, diff truncation, no phase mutation), orchestrator routing (8 cases), and prompt file completeness (8 assertions)

Closes #28