### PR TITLE
fix(core): status_node and research_node now emit visible LLM answers

### DIFF
--- a/app/core/events.py
+++ b/app/core/events.py
@@ -52,6 +52,7 @@ class EventCategory(str, Enum):
     AGENT_THINK = "agent_think"
     AGENT_RESULT = "agent_result"
     AGENT_TOKEN = "agent_token"     # streaming token chunk
+    AGENT_RESPONSE = "agent_response"   # final visible conversational reply
     TOOL_CALL = "tool_call"
     TOOL_RESULT = "tool_result"
     PLAN = "plan"
@@ -191,6 +192,20 @@ def emit_agent_token(agent: str, token: str) -> None:
         category=EventCategory.AGENT_TOKEN,
         agent=agent,
         title=token,
+    ))
+
+
+def emit_agent_response(agent: str, text: str) -> None:
+    """Emit a visible conversational reply (status/research nodes).
+
+    Unlike emit_agent_result (which is hidden in a collapsible), this event
+    is rendered as an auto-expanded reply bubble in the Web UI.
+    """
+    emit(WorkflowEvent(
+        category=EventCategory.AGENT_RESPONSE,
+        agent=agent,
+        title=f"💬 {agent}",
+        detail=text,
     ))
 
 

--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -82,6 +82,21 @@
   .msg-status.status-error { border-left-color: var(--red); background: var(--red-dim); color: var(--red); }
   .msg-status.status-complete { border-left-color: var(--green); background: var(--green-dim); color: var(--green); font-weight: 700; }
 
+  /* Agent response bubble — visible reply from status/research nodes */
+  .msg-response {
+    align-self: flex-start; padding: 12px 16px;
+    background: var(--surface2); border: 1px solid var(--border);
+    border-left: 3px solid var(--purple); border-radius: 6px;
+    color: var(--text); font-size: 13px; line-height: 1.7;
+    white-space: pre-wrap; word-break: break-word;
+    max-width: 95%; width: 100%;
+  }
+  .msg-response .resp-header {
+    display: flex; align-items: center; gap: 8px;
+    margin-bottom: 8px;
+  }
+  .msg-response .resp-body { color: var(--text); }
+
   /* Streaming token blocks — live typewriter output */
   .msg-stream {
     align-self: flex-start; padding: 10px 14px;
@@ -516,6 +531,34 @@ function addUser(text) {
   div.className = 'msg msg-user';
   div.textContent = text;
   chat.appendChild(div);
+  scrollBottom();
+}
+
+// ── Add a visible agent response bubble ─────────────────
+function addResponse(agent, body) {
+  finaliseStream();
+  currentDetailBlock = null;
+  currentDetailTools = null;
+
+  const block = document.createElement('div');
+  block.className = 'msg msg-response';
+
+  const hdr = document.createElement('div');
+  hdr.className = 'resp-header';
+
+  const tag = document.createElement('span');
+  tag.className = `agent-tag ${TAG_CLASS[agent] || 'tag-system'}`;
+  tag.textContent = AGENT_NAMES[agent] || agent;
+
+  hdr.appendChild(tag);
+  block.appendChild(hdr);
+
+  const bodyDiv = document.createElement('div');
+  bodyDiv.className = 'resp-body';
+  bodyDiv.textContent = body;
+  block.appendChild(bodyDiv);
+
+  chat.appendChild(block);
   scrollBottom();
 }
 
@@ -970,6 +1013,11 @@ function handleEvent(evt) {
     case 'agent_token':
       // Streaming token chunk — append to live block
       appendToken(agent, title);
+      break;
+
+    case 'agent_response':
+      // Visible conversational reply from status/research nodes
+      addResponse(agent, detail);
       break;
 
     case 'agent_think':


### PR DESCRIPTION
Bug: status_node returned get_progress_summary() (workflow state) instead of an actual LLM answer for conversational questions like 'who are you?'. Bug: planner_response was written to GraphState but never emitted as any event — the answer was invisible to the Web UI regardless of the question. Bug: research_node had the same missing emit problem.

Fix — events.py:
- Add EventCategory.AGENT_RESPONSE: dedicated category for conversational replies; distinct from AGENT_RESULT (which stays as a closed collapsible)
- Add emit_agent_response(agent, text): emits an AGENT_RESPONSE event

Fix — nodes.py:
- status_node: now calls _invoke_agent('planner', ...) with the user's question plus workflow-state context; calls emit_agent_response() so the answer appears immediately in the UI as a visible reply bubble
- research_node: same fix — calls emit_agent_response() after the LLM call

Fix — index.html:
- Add .msg-response CSS: purple-left-bordered chat bubble, auto-expanded, pre-wrap for multi-line answers, consistent with existing design system
- Add addResponse(agent, body) JS function: creates the bubble, resets streaming/detail state, auto-scrolls
- Add case 'agent_response': in handleEvent() switch → calls addResponse()

Before: 'hallo, wer bist du?' → silence (answer buried in GraphState)
After:  'hallo, wer bist du?' → visible reply bubble from PLANNER