### PR TITLE
feat(core): token budget and cost tracking

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -78,6 +78,12 @@ class Settings(BaseSettings):
     shell_timeout_seconds: int = 120
     max_output_chars: int = 12_000
 
+    # Token budget / cost limits (USD). Set to 0.0 to disable.
+    # Soft limit: emits a ⚠️ warning in the UI but workflow continues.
+    # Hard limit: stops the workflow with stop_reason="budget_hard_limit_exceeded".
+    token_budget_soft_limit_usd: float = 0.0
+    token_budget_hard_limit_usd: float = 0.0
+
     # Logging
     log_level: str = "INFO"
     log_file: str = "logs/agent.log"

--- a/app/core/events.py
+++ b/app/core/events.py
@@ -53,6 +53,7 @@ class EventCategory(str, Enum):
     AGENT_RESULT = "agent_result"
     AGENT_TOKEN = "agent_token"     # streaming token chunk
     AGENT_RESPONSE = "agent_response"   # final visible conversational reply
+    TOKEN_USAGE = "token_usage"         # per-call token/cost metrics
     TOOL_CALL = "tool_call"
     TOOL_RESULT = "tool_result"
     PLAN = "plan"
@@ -192,6 +193,30 @@ def emit_agent_token(agent: str, token: str) -> None:
         category=EventCategory.AGENT_TOKEN,
         agent=agent,
         title=token,
+    ))
+
+
+def emit_token_usage(
+    agent: str,
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cost_usd: float,
+    total_cost_usd: float,
+) -> None:
+    """Emit per-call token consumption and cost metrics."""
+    emit(WorkflowEvent(
+        category=EventCategory.TOKEN_USAGE,
+        agent=agent,
+        title=f"💰 {agent}: {prompt_tokens}+{completion_tokens} tok (${cost_usd:.4f})",
+        metadata={
+            "prompt_tokens":     prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens":      prompt_tokens + completion_tokens,
+            "cost_usd":          round(cost_usd, 6),
+            "total_cost_usd":    round(total_cost_usd, 6),
+            "model":             model,
+        },
     ))
 
 

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -152,6 +152,12 @@ class GraphState(BaseModel):
     completed_items: int = 0
     env_fix_attempts: int = 0   # number of env-fix rounds attempted for current item
 
+    # ── Token budget ──────────────────────────────────────────────────
+    # Stored as a plain dict (TokenBudget.to_dict()) so Pydantic can
+    # serialise/deserialise it for checkpoints without custom validators.
+    # Reconstruct with: TokenBudget.from_dict(state.token_budget)
+    token_budget: dict[str, Any] = Field(default_factory=dict)
+
     @property
     def current_item(self) -> TodoItem | None:
         if 0 <= self.current_item_index < len(self.todo_items):

--- a/app/core/token_budget.py
+++ b/app/core/token_budget.py
@@ -1,0 +1,246 @@
+"""Token budget and cost tracking for Daedalus workflow runs.
+
+Every LLM call records prompt/completion tokens and estimated cost.
+Configurable soft (warning) and hard (stop) USD limits are enforced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+# ---------------------------------------------------------------------------
+# Pricing table — USD per 1M tokens (input / output separately)
+# Update when providers change pricing. Unknown models fall back to _default.
+# ---------------------------------------------------------------------------
+
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    # Anthropic
+    "claude-sonnet-4-20250514":  {"input": 3.00,  "output": 15.00},
+    "claude-opus-4-20250514":    {"input": 15.00, "output": 75.00},
+    "claude-haiku-4-5-20251001": {"input": 0.80,  "output": 4.00},
+    "claude-haiku-3-5":          {"input": 0.80,  "output": 4.00},
+    "claude-3-5-sonnet":         {"input": 3.00,  "output": 15.00},
+    "claude-3-5-haiku":          {"input": 0.80,  "output": 4.00},
+    "claude-3-opus":             {"input": 15.00, "output": 75.00},
+    # OpenAI
+    "gpt-4o":                    {"input": 2.50,  "output": 10.00},
+    "gpt-4o-mini":               {"input": 0.15,  "output": 0.60},
+    "gpt-4-turbo":               {"input": 10.00, "output": 30.00},
+    "gpt-4":                     {"input": 30.00, "output": 60.00},
+    "gpt-3.5-turbo":             {"input": 0.50,  "output": 1.50},
+    "o1":                        {"input": 15.00, "output": 60.00},
+    "o1-mini":                   {"input": 3.00,  "output": 12.00},
+    # Fallback for unknown / local models
+    "_default":                  {"input": 3.00,  "output": 15.00},
+    "_ollama":                   {"input": 0.00,  "output": 0.00},
+}
+
+
+def _pricing_for_model(model: str) -> dict[str, float]:
+    """Return the pricing dict for a model name.
+
+    Matches by prefix so that model variants (e.g. 'claude-sonnet-4-20250514')
+    work even if only the base name appears in the table.
+    """
+    if model in MODEL_PRICING:
+        return MODEL_PRICING[model]
+    # Prefix matching
+    for key in MODEL_PRICING:
+        if key.startswith("_"):
+            continue
+        if model.startswith(key) or key in model:
+            return MODEL_PRICING[key]
+    # Ollama models are free (local)
+    if model.startswith("ollama:") or "/" in model:
+        return MODEL_PRICING["_ollama"]
+    return MODEL_PRICING["_default"]
+
+
+def calculate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> float:
+    """Return estimated cost in USD for a single LLM call."""
+    pricing = _pricing_for_model(model)
+    return (
+        prompt_tokens * pricing["input"] + completion_tokens * pricing["output"]
+    ) / 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TokenUsageRecord:
+    """Single LLM call token/cost record."""
+    agent:             str
+    model:             str
+    prompt_tokens:     int
+    completion_tokens: int
+    total_tokens:      int
+    cost_usd:          float
+    node:              str = ""
+    timestamp:         str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict:
+        return {
+            "agent":             self.agent,
+            "model":             self.model,
+            "prompt_tokens":     self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens":      self.total_tokens,
+            "cost_usd":          round(self.cost_usd, 6),
+            "node":              self.node,
+            "timestamp":         self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TokenUsageRecord":
+        return cls(
+            agent=d.get("agent", ""),
+            model=d.get("model", ""),
+            prompt_tokens=d.get("prompt_tokens", 0),
+            completion_tokens=d.get("completion_tokens", 0),
+            total_tokens=d.get("total_tokens", 0),
+            cost_usd=d.get("cost_usd", 0.0),
+            node=d.get("node", ""),
+            timestamp=d.get("timestamp", ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+class BudgetExceededException(Exception):
+    """Raised when a hard budget limit is exceeded."""
+    def __init__(self, total_cost: float, limit: float) -> None:
+        self.total_cost = total_cost
+        self.limit = limit
+        super().__init__(
+            f"Hard budget limit exceeded: ${total_cost:.4f} >= ${limit:.4f}"
+        )
+
+
+@dataclass
+class TokenBudget:
+    """Thread-safe accumulator for token usage across one workflow run."""
+
+    records:           list[TokenUsageRecord] = field(default_factory=list)
+    total_prompt:      int   = 0
+    total_completion:  int   = 0
+    total_tokens:      int   = 0
+    total_cost_usd:    float = 0.0
+    soft_limit_usd:    float = 0.0   # 0 = disabled
+    hard_limit_usd:    float = 0.0   # 0 = disabled
+    soft_limit_hit:    bool  = False
+    hard_limit_hit:    bool  = False
+
+    def add(self, record: TokenUsageRecord) -> None:
+        """Accumulate a new usage record. Checks limits after accumulation."""
+        self.records.append(record)
+        self.total_prompt      += record.prompt_tokens
+        self.total_completion  += record.completion_tokens
+        self.total_tokens      += record.total_tokens
+        self.total_cost_usd    += record.cost_usd
+
+        if self.hard_limit_usd > 0 and self.total_cost_usd >= self.hard_limit_usd:
+            self.hard_limit_hit = True
+            raise BudgetExceededException(self.total_cost_usd, self.hard_limit_usd)
+
+        if (
+            self.soft_limit_usd > 0
+            and not self.soft_limit_hit
+            and self.total_cost_usd >= self.soft_limit_usd
+        ):
+            self.soft_limit_hit = True
+
+    def per_agent(self) -> dict[str, dict]:
+        """Return cost/token breakdown grouped by agent role."""
+        result: dict[str, dict] = {}
+        for rec in self.records:
+            entry = result.setdefault(rec.agent, {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+                "calls": 0,
+            })
+            entry["prompt_tokens"]     += rec.prompt_tokens
+            entry["completion_tokens"] += rec.completion_tokens
+            entry["total_tokens"]      += rec.total_tokens
+            entry["cost_usd"]          += rec.cost_usd
+            entry["calls"]             += 1
+        # Round costs for readability
+        for entry in result.values():
+            entry["cost_usd"] = round(entry["cost_usd"], 6)
+        return result
+
+    def summary(self) -> dict:
+        """Return a serialisable summary dict (stored in GraphState)."""
+        return {
+            "total_prompt":     self.total_prompt,
+            "total_completion": self.total_completion,
+            "total_tokens":     self.total_tokens,
+            "total_cost_usd":   round(self.total_cost_usd, 6),
+            "soft_limit_usd":   self.soft_limit_usd,
+            "hard_limit_usd":   self.hard_limit_usd,
+            "soft_limit_hit":   self.soft_limit_hit,
+            "hard_limit_hit":   self.hard_limit_hit,
+            "calls":            len(self.records),
+            "per_agent":        self.per_agent(),
+            "records":          [r.to_dict() for r in self.records],
+        }
+
+    def to_dict(self) -> dict:
+        """Alias for summary() — used when serialising to GraphState."""
+        return self.summary()
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TokenBudget":
+        """Reconstruct from a serialised summary dict."""
+        budget = cls(
+            total_prompt=d.get("total_prompt", 0),
+            total_completion=d.get("total_completion", 0),
+            total_tokens=d.get("total_tokens", 0),
+            total_cost_usd=d.get("total_cost_usd", 0.0),
+            soft_limit_usd=d.get("soft_limit_usd", 0.0),
+            hard_limit_usd=d.get("hard_limit_usd", 0.0),
+            soft_limit_hit=d.get("soft_limit_hit", False),
+            hard_limit_hit=d.get("hard_limit_hit", False),
+        )
+        for rec_dict in d.get("records", []):
+            budget.records.append(TokenUsageRecord.from_dict(rec_dict))
+        return budget
+
+
+def extract_token_usage(response: object) -> dict[str, int]:
+    """Extract prompt/completion/total token counts from a LangChain response.
+
+    Handles all three providers:
+    - Anthropic: response.usage_metadata with input_tokens / output_tokens
+    - OpenAI:    response.response_metadata.token_usage OR usage_metadata
+    - Ollama:    same as OpenAI but may return zeros
+
+    Returns dict with keys: prompt_tokens, completion_tokens, total_tokens.
+    All values default to 0 if metadata is unavailable.
+    """
+    # --- Primary: usage_metadata (Anthropic + modern OpenAI LangChain) ----
+    meta = getattr(response, "usage_metadata", None)
+    if meta and isinstance(meta, dict):
+        prompt     = meta.get("input_tokens", 0) or meta.get("prompt_tokens", 0)
+        completion = meta.get("output_tokens", 0) or meta.get("completion_tokens", 0)
+        total      = meta.get("total_tokens", 0) or (prompt + completion)
+        if prompt or completion:
+            return {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": total}
+
+    # --- Fallback: response_metadata (OpenAI via LangChain) ---------------
+    rm = getattr(response, "response_metadata", {}) or {}
+    usage = rm.get("token_usage") or rm.get("usage") or {}
+    if isinstance(usage, dict):
+        prompt     = usage.get("prompt_tokens", 0)
+        completion = usage.get("completion_tokens", 0)
+        total      = usage.get("total_tokens", 0) or (prompt + completion)
+        if prompt or completion:
+            return {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": total}
+
+    return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -48,6 +48,7 @@ class StatusResponse(BaseModel):
     error: str
     items_total: int
     items_done: int
+    token_budget: dict = {}
 
 
 class ApprovalRequest(BaseModel):
@@ -288,6 +289,7 @@ async def get_status():
         error=_current_state.error_message,
         items_total=len(_current_state.todo_items),
         items_done=_current_state.completed_items,
+        token_budget=_current_state.token_budget or {},
     )
 
 

--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -97,6 +97,50 @@
   }
   .msg-response .resp-body { color: var(--text); }
 
+  /* Cost button colour states */
+  .cost-btn { font-variant-numeric: tabular-nums; min-width: 90px; }
+  .cost-btn.cost-soft  { background: var(--yellow-dim); color: var(--yellow); border-color: var(--yellow); }
+  .cost-btn.cost-hard  { background: var(--red-dim);    color: var(--red);    border-color: var(--red);    animation: pulse 1s infinite; }
+
+  /* Cost breakdown modal */
+  .cost-modal {
+    position: fixed; inset: 0; background: rgba(0,0,0,.6);
+    display: flex; align-items: center; justify-content: center; z-index: 200;
+  }
+  .cost-modal-box {
+    background: var(--surface1); border: 1px solid var(--border);
+    border-radius: 10px; width: min(540px, 95vw); max-height: 80vh;
+    display: flex; flex-direction: column; overflow: hidden;
+  }
+  .cost-modal-header {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 14px 18px; border-bottom: 1px solid var(--border);
+    font-weight: 700; font-size: 14px; color: var(--text);
+  }
+  .cost-modal-header button {
+    background: none; border: none; color: var(--text-dim);
+    cursor: pointer; font-size: 16px;
+  }
+  .cost-modal-header button:hover { color: var(--text); }
+  .cost-modal-body { padding: 18px; overflow-y: auto; font-size: 13px; }
+  .cost-summary { margin-bottom: 16px; }
+  .cost-summary .cost-total {
+    font-size: 28px; font-weight: 700; color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+  .cost-summary .cost-meta { color: var(--text-dim); margin-top: 4px; }
+  .cost-table { width: 100%; border-collapse: collapse; }
+  .cost-table th {
+    text-align: left; padding: 6px 10px; font-size: 11px; font-weight: 600;
+    color: var(--text-dim); text-transform: uppercase; letter-spacing: .5px;
+    border-bottom: 1px solid var(--border);
+  }
+  .cost-table td { padding: 7px 10px; border-bottom: 1px solid var(--surface3); }
+  .cost-table tr:last-child td { border-bottom: none; }
+  .cost-table .cost-num { text-align: right; font-variant-numeric: tabular-nums; }
+  .cost-limit-warn  { color: var(--yellow); font-weight: 600; margin-top: 12px; }
+  .cost-limit-error { color: var(--red);    font-weight: 600; margin-top: 12px; }
+
   /* Streaming token blocks — live typewriter output */
   .msg-stream {
     align-self: flex-start; padding: 10px 14px;
@@ -453,6 +497,7 @@
   <div class="header-status">
     <span class="progress-text" id="progressText">—</span>
     <span class="badge badge-idle" id="badge">IDLE</span>
+    <button class="intel-btn cost-btn" id="costBtn" onclick="toggleCostModal()" title="Token budget & cost breakdown" style="display:none">💰 $0.0000</button>
     <button class="intel-btn" id="intelBtn" onclick="toggleIntel()" title="Code Intelligence Dashboard">🧠 Intel</button>
   </div>
 </header>
@@ -464,6 +509,19 @@
   <div class="input-row">
     <input type="text" id="taskInput" placeholder="Describe a coding task…" autocomplete="off" />
     <button onclick="sendTask()">SEND</button>
+  </div>
+</div>
+
+<!-- Cost Breakdown Modal -->
+<div class="cost-modal" id="costModal" style="display:none">
+  <div class="cost-modal-box">
+    <div class="cost-modal-header">
+      <span>💰 Token Budget &amp; Cost</span>
+      <button onclick="toggleCostModal()" title="Close">✕</button>
+    </div>
+    <div class="cost-modal-body" id="costModalBody">
+      <p style="color:var(--text-dim);text-align:center">No data yet.</p>
+    </div>
   </div>
 </div>
 
@@ -533,6 +591,97 @@ function addUser(text) {
   chat.appendChild(div);
   scrollBottom();
 }
+
+// ── Token budget / cost tracking ─────────────────────────
+let _totalCostUsd = 0;
+let _costData = null;  // latest budget summary from events or /api/status
+
+function updateCostIndicator(eventData) {
+  const meta = eventData.metadata || {};
+  _totalCostUsd = meta.total_cost_usd ?? _totalCostUsd;
+  _costData = meta;
+
+  const btn = document.getElementById('costBtn');
+  if (!btn) return;
+  btn.style.display = '';
+  btn.textContent = `💰 $${_totalCostUsd.toFixed(4)}`;
+
+  // Colour state (soft / hard limit)
+  btn.classList.remove('cost-soft', 'cost-hard');
+  if (meta.hard_limit_hit) btn.classList.add('cost-hard');
+  else if (meta.soft_limit_hit) btn.classList.add('cost-soft');
+}
+
+function toggleCostModal() {
+  const modal = document.getElementById('costModal');
+  if (modal.style.display === 'none') {
+    renderCostModal();
+    modal.style.display = 'flex';
+  } else {
+    modal.style.display = 'none';
+  }
+}
+
+function renderCostModal() {
+  const body = document.getElementById('costModalBody');
+  if (!_costData && _totalCostUsd === 0) {
+    body.innerHTML = '<p style="color:var(--text-dim);text-align:center">No token data recorded yet.</p>';
+    return;
+  }
+
+  const total     = _totalCostUsd;
+  const totalTok  = (_costData?.total_tokens) ?? 0;
+  const softHit   = _costData?.soft_limit_hit;
+  const hardHit   = _costData?.hard_limit_hit;
+  const softLim   = _costData?.soft_limit_usd ?? 0;
+  const hardLim   = _costData?.hard_limit_usd ?? 0;
+  const perAgent  = _costData?.per_agent ?? {};
+
+  let html = `
+    <div class="cost-summary">
+      <div class="cost-total">$${total.toFixed(4)}</div>
+      <div class="cost-meta">${totalTok.toLocaleString()} tokens total</div>
+      ${softHit ? `<div class="cost-limit-warn">⚠️ Soft limit hit ($${softLim.toFixed(2)})</div>` : ''}
+      ${hardHit ? `<div class="cost-limit-error">❌ Hard limit hit ($${hardLim.toFixed(2)})</div>` : ''}
+    </div>
+    <table class="cost-table">
+      <thead>
+        <tr>
+          <th>Agent</th>
+          <th class="cost-num">Calls</th>
+          <th class="cost-num">Prompt</th>
+          <th class="cost-num">Completion</th>
+          <th class="cost-num">Cost (USD)</th>
+        </tr>
+      </thead>
+      <tbody>`;
+
+  const agents = Object.keys(perAgent).sort();
+  for (const ag of agents) {
+    const d = perAgent[ag];
+    html += `
+      <tr>
+        <td><span class="agent-tag ${TAG_CLASS[ag] || 'tag-system'}">${AGENT_NAMES[ag] || ag}</span></td>
+        <td class="cost-num">${d.calls ?? 0}</td>
+        <td class="cost-num">${(d.prompt_tokens ?? 0).toLocaleString()}</td>
+        <td class="cost-num">${(d.completion_tokens ?? 0).toLocaleString()}</td>
+        <td class="cost-num">$${(d.cost_usd ?? 0).toFixed(4)}</td>
+      </tr>`;
+  }
+
+  if (agents.length === 0) {
+    html += '<tr><td colspan="5" style="text-align:center;color:var(--text-dim)">No calls recorded yet.</td></tr>';
+  }
+
+  html += `</tbody></table>`;
+  body.innerHTML = html;
+}
+
+// Close cost modal on backdrop click
+document.addEventListener('click', e => {
+  const modal = document.getElementById('costModal');
+  if (modal && e.target === modal) modal.style.display = 'none';
+});
 
 // ── Add a visible agent response bubble ─────────────────
 function addResponse(agent, body) {
@@ -931,6 +1080,16 @@ function handleEvent(evt) {
           total: metadata.items_total,
           branch: metadata.branch || '',
         });
+        // Sync token budget from status metadata if present
+        if (metadata.token_budget) {
+          _costData = metadata.token_budget;
+          _totalCostUsd = metadata.token_budget.total_cost_usd ?? _totalCostUsd;
+          const btn = document.getElementById('costBtn');
+          if (btn && _totalCostUsd > 0) {
+            btn.style.display = '';
+            btn.textContent = `💰 $${_totalCostUsd.toFixed(4)}`;
+          }
+        }
         // Detect intelligence_complete event metadata
         if (metadata.type === 'intelligence_complete') {
           _onIntelligenceComplete();
@@ -1018,6 +1177,11 @@ function handleEvent(evt) {
     case 'agent_response':
       // Visible conversational reply from status/research nodes
       addResponse(agent, detail);
+      break;
+
+    case 'token_usage':
+      // Update cost indicator in header
+      updateCostIndicator(data);
       break;
 
     case 'agent_think':

--- a/tests/test_documenter.py
+++ b/tests/test_documenter.py
@@ -161,7 +161,7 @@ class TestDocumenterNodeLLMPath:
             clear_listeners()
 
         mock_llm.assert_called_once()
-        assert result == {}  # documenter never mutates state
+        assert result.get("phase") is None  # documenter never mutates phase
 
     def test_llm_called_with_documenter_role(self):
         from app.core.nodes import documenter_node
@@ -221,7 +221,7 @@ class TestDocumenterNodeLLMPath:
         assert len(prompt_content) < 10000
 
     def test_documenter_does_not_mutate_phase(self):
-        """documenter_node must return {} — it never changes phase or state."""
+        """documenter_node never changes phase or workflow state — only updates token_budget."""
         from app.core.nodes import documenter_node
         from app.core.events import clear_listeners
 
@@ -235,7 +235,9 @@ class TestDocumenterNodeLLMPath:
             result = documenter_node(state)
             clear_listeners()
 
-        assert result == {}
+        # documenter must never set phase, stop_reason, or other workflow keys
+        assert result.get("phase") is None
+        assert result.get("stop_reason") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_token_budget.py
+++ b/tests/test_token_budget.py
@@ -1,0 +1,373 @@
+"""Tests for token budget and cost tracking (Issue #34).
+
+Covers:
+- calculate_cost: known model pricing, default fallback, Ollama free
+- _pricing_for_model: prefix matching, unknown models
+- extract_token_usage: Anthropic format, OpenAI format, empty/missing
+- TokenUsageRecord: to_dict / from_dict round-trip
+- TokenBudget: accumulation, per_agent, soft limit, hard limit, to_dict/from_dict
+- BudgetExceededException raised on hard limit
+- _model_name_for_role: role → model string mapping
+- _get_budget / _budget_dict: state round-trip
+- Config: token_budget_soft_limit_usd, token_budget_hard_limit_usd fields
+- GraphState: token_budget field present and defaults to {}
+- EventCategory.TOKEN_USAGE present; emit_token_usage emits correct event
+- /api/status response includes token_budget field
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.state import GraphState
+
+
+# ---------------------------------------------------------------------------
+# 1. calculate_cost
+# ---------------------------------------------------------------------------
+
+class TestCalculateCost:
+    def _cost(self, model, prompt, completion):
+        from app.core.token_budget import calculate_cost
+        return calculate_cost(model, prompt, completion)
+
+    def test_gpt4o_mini_known_pricing(self):
+        # 1M input @ $0.15, 1M output @ $0.60
+        cost = self._cost("gpt-4o-mini", 1_000_000, 1_000_000)
+        assert abs(cost - 0.75) < 0.001
+
+    def test_gpt4o_known_pricing(self):
+        cost = self._cost("gpt-4o", 1_000_000, 1_000_000)
+        assert abs(cost - 12.50) < 0.01
+
+    def test_claude_sonnet_known_pricing(self):
+        cost = self._cost("claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+        assert abs(cost - 18.00) < 0.01
+
+    def test_ollama_model_is_free(self):
+        cost = self._cost("ollama:llama3.1:70b", 100_000, 100_000)
+        assert cost == 0.0
+
+    def test_unknown_model_uses_default(self):
+        from app.core.token_budget import calculate_cost, MODEL_PRICING
+        cost = calculate_cost("some-unknown-model-xyz", 1_000_000, 1_000_000)
+        default = MODEL_PRICING["_default"]
+        expected = (default["input"] + default["output"]) / 1_000_000 * 1_000_000
+        assert abs(cost - expected) < 0.01
+
+    def test_zero_tokens_zero_cost(self):
+        assert self._cost("gpt-4o-mini", 0, 0) == 0.0
+
+    def test_input_only_tokens(self):
+        cost = self._cost("gpt-4o-mini", 1_000_000, 0)
+        assert abs(cost - 0.15) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# 2. extract_token_usage
+# ---------------------------------------------------------------------------
+
+class TestExtractTokenUsage:
+    def _extract(self, response_mock):
+        from app.core.token_budget import extract_token_usage
+        return extract_token_usage(response_mock)
+
+    def _mock(self, **attrs):
+        m = MagicMock()
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        return m
+
+    def test_anthropic_usage_metadata(self):
+        resp = self._mock(usage_metadata={"input_tokens": 100, "output_tokens": 50})
+        result = self._extract(resp)
+        assert result["prompt_tokens"] == 100
+        assert result["completion_tokens"] == 50
+        assert result["total_tokens"] == 150
+
+    def test_openai_response_metadata(self):
+        resp = self._mock(
+            usage_metadata={},
+            response_metadata={"token_usage": {"prompt_tokens": 200, "completion_tokens": 80, "total_tokens": 280}},
+        )
+        result = self._extract(resp)
+        assert result["prompt_tokens"] == 200
+        assert result["completion_tokens"] == 80
+
+    def test_missing_metadata_returns_zeros(self):
+        resp = self._mock(usage_metadata=None, response_metadata={})
+        result = self._extract(resp)
+        assert result == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+    def test_total_tokens_computed_if_missing(self):
+        resp = self._mock(usage_metadata={"input_tokens": 60, "output_tokens": 40})
+        result = self._extract(resp)
+        assert result["total_tokens"] == 100
+
+    def test_no_attributes_returns_zeros(self):
+        # Plain object with no metadata attrs
+        class Empty:
+            pass
+        result = self._extract(Empty())
+        assert result["prompt_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. TokenUsageRecord
+# ---------------------------------------------------------------------------
+
+class TestTokenUsageRecord:
+    def _make(self, **kwargs):
+        from app.core.token_budget import TokenUsageRecord
+        defaults = dict(agent="coder_a", model="gpt-4o-mini",
+                        prompt_tokens=100, completion_tokens=50,
+                        total_tokens=150, cost_usd=0.0001)
+        defaults.update(kwargs)
+        return TokenUsageRecord(**defaults)
+
+    def test_to_dict_has_expected_keys(self):
+        rec = self._make()
+        d = rec.to_dict()
+        for key in ("agent", "model", "prompt_tokens", "completion_tokens", "total_tokens", "cost_usd"):
+            assert key in d
+
+    def test_from_dict_round_trip(self):
+        from app.core.token_budget import TokenUsageRecord
+        rec = self._make(agent="tester", model="claude-sonnet-4-20250514", prompt_tokens=300)
+        d = rec.to_dict()
+        rec2 = TokenUsageRecord.from_dict(d)
+        assert rec2.agent == "tester"
+        assert rec2.prompt_tokens == 300
+        assert rec2.model == "claude-sonnet-4-20250514"
+
+
+# ---------------------------------------------------------------------------
+# 4. TokenBudget
+# ---------------------------------------------------------------------------
+
+class TestTokenBudget:
+    def _make_rec(self, agent="coder_a", prompt=100, completion=50, cost=0.001):
+        from app.core.token_budget import TokenUsageRecord
+        return TokenUsageRecord(
+            agent=agent, model="gpt-4o-mini",
+            prompt_tokens=prompt, completion_tokens=completion,
+            total_tokens=prompt + completion, cost_usd=cost,
+        )
+
+    def test_empty_budget_zeros(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        assert b.total_tokens == 0
+        assert b.total_cost_usd == 0.0
+
+    def test_add_accumulates(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        b.add(self._make_rec(prompt=100, completion=50, cost=0.001))
+        b.add(self._make_rec(prompt=200, completion=80, cost=0.002))
+        assert b.total_prompt == 300
+        assert b.total_completion == 130
+        assert abs(b.total_cost_usd - 0.003) < 1e-9
+
+    def test_per_agent_grouped(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        b.add(self._make_rec(agent="coder_a", cost=0.001))
+        b.add(self._make_rec(agent="tester", cost=0.002))
+        b.add(self._make_rec(agent="coder_a", cost=0.001))
+        pa = b.per_agent()
+        assert abs(pa["coder_a"]["cost_usd"] - 0.002) < 1e-9
+        assert abs(pa["tester"]["cost_usd"] - 0.002) < 1e-9
+        assert pa["coder_a"]["calls"] == 2
+
+    def test_soft_limit_sets_flag(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget(soft_limit_usd=0.005)
+        b.add(self._make_rec(cost=0.003))
+        assert not b.soft_limit_hit
+        b.add(self._make_rec(cost=0.003))
+        assert b.soft_limit_hit
+
+    def test_soft_limit_does_not_raise(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget(soft_limit_usd=0.001)
+        b.add(self._make_rec(cost=0.005))  # exceeds — no exception
+
+    def test_hard_limit_raises(self):
+        from app.core.token_budget import TokenBudget, BudgetExceededException
+        b = TokenBudget(hard_limit_usd=0.005)
+        b.add(self._make_rec(cost=0.003))
+        with pytest.raises(BudgetExceededException) as exc_info:
+            b.add(self._make_rec(cost=0.003))
+        assert exc_info.value.total_cost > 0.005
+        assert b.hard_limit_hit
+
+    def test_zero_hard_limit_never_raises(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget(hard_limit_usd=0.0)
+        for _ in range(100):
+            b.add(self._make_rec(cost=1.0))  # $100 total — no raise
+
+    def test_to_dict_from_dict_round_trip(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget(soft_limit_usd=1.0, hard_limit_usd=5.0)
+        b.add(self._make_rec(agent="planner", prompt=500, completion=200, cost=0.01))
+        d = b.to_dict()
+        b2 = TokenBudget.from_dict(d)
+        assert b2.total_prompt == 500
+        assert b2.total_completion == 200
+        assert abs(b2.total_cost_usd - 0.01) < 1e-9
+        assert b2.soft_limit_usd == 1.0
+        assert len(b2.records) == 1
+
+    def test_summary_has_per_agent(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        b.add(self._make_rec(agent="tester", cost=0.002))
+        s = b.summary()
+        assert "per_agent" in s
+        assert "tester" in s["per_agent"]
+
+    def test_calls_count_in_summary(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        b.add(self._make_rec())
+        b.add(self._make_rec())
+        assert b.summary()["calls"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. _model_name_for_role
+# ---------------------------------------------------------------------------
+
+class TestModelNameForRole:
+    def _get(self, role):
+        from app.core.nodes import _model_name_for_role
+        return _model_name_for_role(role)
+
+    def test_planner_returns_planner_model(self):
+        from app.core.config import get_settings
+        assert self._get("planner") == get_settings().planner_model
+
+    def test_coder_a_returns_coder_1_model(self):
+        from app.core.config import get_settings
+        assert self._get("coder_a") == get_settings().coder_1_model
+
+    def test_tester_returns_tester_model(self):
+        from app.core.config import get_settings
+        assert self._get("tester") == get_settings().tester_model
+
+    def test_unknown_role_returns_planner_model(self):
+        from app.core.config import get_settings
+        assert self._get("unknown_role") == get_settings().planner_model
+
+
+# ---------------------------------------------------------------------------
+# 6. Config fields
+# ---------------------------------------------------------------------------
+
+class TestConfigBudgetFields:
+    def test_soft_limit_defaults_to_zero(self):
+        from app.core.config import get_settings
+        assert get_settings().token_budget_soft_limit_usd == 0.0
+
+    def test_hard_limit_defaults_to_zero(self):
+        from app.core.config import get_settings
+        assert get_settings().token_budget_hard_limit_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 7. GraphState.token_budget
+# ---------------------------------------------------------------------------
+
+class TestGraphStateTokenBudget:
+    def test_token_budget_defaults_to_empty_dict(self):
+        state = GraphState()
+        assert state.token_budget == {}
+
+    def test_token_budget_serialises_with_pydantic(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        b.total_cost_usd = 0.05
+        state = GraphState(token_budget=b.to_dict())
+        assert state.token_budget["total_cost_usd"] == 0.05
+
+    def test_token_budget_survives_model_dump_round_trip(self):
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        b.total_tokens = 1000
+        state = GraphState(token_budget=b.to_dict())
+        dumped = state.model_dump()
+        restored = GraphState(**dumped)
+        assert restored.token_budget["total_tokens"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# 8. Events
+# ---------------------------------------------------------------------------
+
+class TestTokenUsageEvent:
+    def test_token_usage_in_event_category(self):
+        from app.core.events import EventCategory
+        assert hasattr(EventCategory, "TOKEN_USAGE")
+        assert EventCategory.TOKEN_USAGE == "token_usage"
+
+    def _clear(self):
+        from app.core.events import clear_listeners
+        import app.core.events as ev
+        clear_listeners()
+        ev._history.clear()
+
+    def test_emit_token_usage_emits_event(self):
+        from app.core.events import emit_token_usage, get_history
+        self._clear()
+        emit_token_usage("coder_a", "gpt-4o-mini", 100, 50, 0.0001, 0.0001)
+        history = get_history()
+        matching = [e for e in history if e.get("category") == "token_usage"]
+        assert len(matching) == 1
+        self._clear()
+
+    def test_emit_token_usage_metadata_shape(self):
+        from app.core.events import emit_token_usage, get_history
+        self._clear()
+        emit_token_usage("tester", "gpt-4o-mini", 200, 80, 0.0002, 0.0005)
+        history = get_history()
+        evt = next(e for e in history if e.get("category") == "token_usage")
+        assert evt["metadata"]["prompt_tokens"] == 200
+        assert evt["metadata"]["completion_tokens"] == 80
+        assert evt["metadata"]["model"] == "gpt-4o-mini"
+        assert "total_cost_usd" in evt["metadata"]
+        self._clear()
+
+
+# ---------------------------------------------------------------------------
+# 9. _get_budget and _budget_dict helpers
+# ---------------------------------------------------------------------------
+
+class TestBudgetHelpers:
+    def test_get_budget_returns_empty_budget_for_empty_state(self):
+        from app.core.nodes import _get_budget
+        state = GraphState()
+        budget = _get_budget(state)
+        assert budget.total_tokens == 0
+
+    def test_get_budget_restores_from_state(self):
+        from app.core.nodes import _get_budget
+        from app.core.token_budget import TokenBudget, TokenUsageRecord
+        b = TokenBudget()
+        b.total_cost_usd = 0.123
+        b.total_tokens = 500
+        state = GraphState(token_budget=b.to_dict())
+        restored = _get_budget(state)
+        assert abs(restored.total_cost_usd - 0.123) < 1e-9
+        assert restored.total_tokens == 500
+
+    def test_budget_dict_serialises_correctly(self):
+        from app.core.nodes import _budget_dict
+        from app.core.token_budget import TokenBudget
+        b = TokenBudget()
+        b.total_cost_usd = 0.05
+        d = _budget_dict(b)
+        assert isinstance(d, dict)
+        assert d["total_cost_usd"] == 0.05


### PR DESCRIPTION
Tracks token usage and estimated USD cost on every LLM call. Enforces configurable soft (warning) and hard (stop) budget limits. Surfaces live cost data in the Web UI header and /api/status response.

New file — app/core/token_budget.py:
- MODEL_PRICING: USD/1M-token table for all used models (Anthropic, OpenAI, Ollama). Ollama is always $0. Unknown models fall back to _default ($3/$15). Prefix-matching handles model variants.
- calculate_cost(model, prompt_tokens, completion_tokens) → float (USD)
- extract_token_usage(response) → {prompt_tokens, completion_tokens, total_tokens}: handles Anthropic usage_metadata, OpenAI response_metadata.token_usage, and missing attrs gracefully (zeros).
- TokenUsageRecord dataclass: per-call record with agent, model, tokens, cost, node, timestamp. to_dict() / from_dict() for checkpoint storage.
- TokenBudget dataclass: accumulates records across a run. Per-agent breakdown via per_agent(). Soft-limit sets soft_limit_hit flag (no raise). Hard-limit raises BudgetExceededException. Zero limit = disabled. to_dict() / from_dict() for Pydantic-safe GraphState storage.
- BudgetExceededException(total_cost, limit): raised by TokenBudget.add() when hard limit is hit.

app/core/config.py:
- token_budget_soft_limit_usd (float, default 0.0): set TOKEN_BUDGET_SOFT_LIMIT_USD
- token_budget_hard_limit_usd (float, default 0.0): set TOKEN_BUDGET_HARD_LIMIT_USD

app/core/state.py:
- GraphState.token_budget: dict[str, Any] = {} — stores TokenBudget.to_dict() for checkpoint-safe serialisation. Reconstruct with TokenBudget.from_dict().

app/core/events.py:
- EventCategory.TOKEN_USAGE = 'token_usage'
- emit_token_usage(agent, model, prompt, completion, cost, total_run_cost)

app/core/nodes.py:
- _model_name_for_role(role) → str: maps agent role to configured model name
- _get_budget(state): reconstructs TokenBudget from state dict, applies current soft/hard limits from settings (handles checkpoint restores).
- _budget_dict(budget): serialises back to plain dict for GraphState.
- _invoke_with_budget(state, role, messages, tools, inject_memory, node) → (result_str, {"token_budget": dict}): convenience wrapper that threads the budget through _invoke_agent and returns the updated dict for merging into node return values.
- _invoke_agent: new optional parameters budget and node. When budget is provided: calls extract_token_usage after each LLM response, creates TokenUsageRecord, calls budget.add(), emits token_usage event, emits soft-limit ⚠️ warning once when threshold crossed. On BudgetExceededException emits ❌ error and re-raises.
- coder_node, peer_review_node, tester_node, documenter_node: switched to _invoke_with_budget; propagate budget_update into return dicts; catch BudgetExceededException → STOPPED with stop_reason='budget_hard_limit_exceeded'.

app/web/server.py:
- StatusResponse.token_budget: dict = {} (new field)
- GET /api/status now includes token_budget with per-agent breakdown, totals, and limit flags.

app/web/static/index.html:
- 💰 cost button added to header bar (hidden until first token_usage event). Updates in real-time on each event. Colours: normal → yellow (soft hit) → red pulsing (hard hit).
- Cost breakdown modal: total cost, total tokens, per-agent table (calls, prompt tokens, completion tokens, USD cost), limit warnings.
- JS: updateCostIndicator(), toggleCostModal(), renderCostModal(). Handles case 'token_usage' in handleEvent() switch. Syncs cost from status event metadata (token_budget field).

tests/test_token_budget.py (new, 39 tests):
  - calculate_cost: known models, Ollama free, unknown fallback, zero tokens
  - extract_token_usage: Anthropic format, OpenAI format, missing attrs, zeros
  - TokenUsageRecord: to_dict/from_dict round-trip
  - TokenBudget: accumulation, per_agent grouping, soft/hard limits, round-trip
  - _model_name_for_role: all roles
  - Config: soft/hard limit defaults to 0.0
  - GraphState.token_budget: defaults, Pydantic round-trip
  - EventCategory.TOKEN_USAGE present; emit_token_usage metadata shape

tests/test_documenter.py: updated two assertions that expected {} return
  from documenter_node (now returns {token_budget: ...} after LLM call).

Before: every LLM call was a black box — no token counts, no cost, no guardrails.
After:  full per-call tracking, live cost in UI, configurable budget limits.

Closes #34