### PR TITLE
feat(core): context window management — truncation, compression, live…

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -84,6 +84,16 @@ class Settings(BaseSettings):
     token_budget_soft_limit_usd: float = 0.0
     token_budget_hard_limit_usd: float = 0.0
 
+    # Context window management
+    # Trigger message-history compression when this fraction of the model's
+    # context window is estimated to be used. 0.0 = never compress.
+    context_warn_fraction: float = 0.75
+    # Number of most-recent messages always kept intact during compression.
+    context_keep_recent_messages: int = 6
+    # Hard limit on a single tool result's char count before it enters all_messages.
+    # Prevents one large read_file call from consuming the context window.
+    tool_result_max_chars: int = 8_000
+
     # Logging
     log_level: str = "INFO"
     log_file: str = "logs/agent.log"

--- a/app/core/context_window.py
+++ b/app/core/context_window.py
@@ -1,0 +1,228 @@
+"""Context window management for Daedalus LLM calls.
+
+Provides token estimation, per-model context limits, tool-result truncation,
+and message-history compression to keep `all_messages` within safe bounds
+during `_invoke_agent()` tool-call loops.
+
+Design notes:
+- No tiktoken dependency — uses a conservative chars/token heuristic.
+- Compression pattern mirrors `_compress_memory_file` in nodes.py / memory.py:
+  the planner LLM summarises old turns into a compact HumanMessage block.
+- `truncate_tool_result` extends the existing `_truncate_context_text` pattern
+  to dynamic tool results (same idea, different marker style).
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+# ---------------------------------------------------------------------------
+# Token estimation
+# ---------------------------------------------------------------------------
+
+# Conservative ratio: code is ~3.5 chars/token, prose ~4.
+# Using 3.0 to err on the side of over-counting (safer).
+CHARS_PER_TOKEN: float = 3.0
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count for a text string using a chars/token heuristic."""
+    return max(1, int(len(text) / CHARS_PER_TOKEN))
+
+
+def estimate_messages_tokens(messages: list) -> int:
+    """Estimate total tokens for a list of LangChain messages.
+
+    Each message gets +4 tokens of overhead (role prefix, delimiters).
+    """
+    total = 0
+    for msg in messages:
+        content = getattr(msg, "content", None) or str(msg)
+        # Multi-modal content is a list of dicts
+        if isinstance(content, list):
+            content = " ".join(
+                c.get("text", "") if isinstance(c, dict) else str(c)
+                for c in content
+            )
+        total += estimate_tokens(str(content)) + 4
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Model context limits
+# ---------------------------------------------------------------------------
+
+# Input context window sizes in tokens.
+# Prefix-matched — variants like 'claude-sonnet-4-20250514-v2' still resolve.
+MODEL_CONTEXT_LIMITS: dict[str, int] = {
+    # Anthropic
+    "claude-sonnet-4-20250514":  200_000,
+    "claude-opus-4-20250514":    200_000,
+    "claude-haiku-4-5-20251001": 200_000,
+    "claude-3-5-sonnet":         200_000,
+    "claude-3-5-haiku":          200_000,
+    "claude-3-opus":             200_000,
+    "claude-3-sonnet":           200_000,
+    "claude-3-haiku":            200_000,
+    # OpenAI
+    "gpt-4o":                    128_000,
+    "gpt-4o-mini":               128_000,
+    "gpt-4-turbo":               128_000,
+    "gpt-4":                       8_192,
+    "gpt-3.5-turbo":              16_385,
+    "o1":                        200_000,
+    "o1-mini":                   128_000,
+    # Fallbacks
+    "_default":                   32_000,   # conservative for unknown models
+    "_ollama":                    32_000,   # Ollama varies; safe default
+}
+
+
+def context_limit_for_model(model: str) -> int:
+    """Return the known context-window limit for a model name.
+
+    Uses prefix matching so that variant names resolve correctly.
+    Unknown models get a conservative 32k default.
+    """
+    if model in MODEL_CONTEXT_LIMITS:
+        return MODEL_CONTEXT_LIMITS[model]
+    # Prefix matching
+    for key, limit in MODEL_CONTEXT_LIMITS.items():
+        if key.startswith("_"):
+            continue
+        if model.startswith(key) or key in model:
+            return limit
+    # Ollama models
+    if model.startswith("ollama:") or "/" in model:
+        return MODEL_CONTEXT_LIMITS["_ollama"]
+    return MODEL_CONTEXT_LIMITS["_default"]
+
+
+def context_usage_fraction(messages: list, model: str) -> float:
+    """Return the fraction of the model's context window used (0.0–1.0+).
+
+    Values > 1.0 indicate the context is already over the limit.
+    """
+    estimated = estimate_messages_tokens(messages)
+    limit = context_limit_for_model(model)
+    return estimated / limit
+
+
+# ---------------------------------------------------------------------------
+# Tool-result truncation
+# ---------------------------------------------------------------------------
+
+# Default max chars for a single tool result before truncation.
+# Mirrors the existing max_output_chars setting but applied at the
+# message-assembly level as a last line of defence.
+DEFAULT_TOOL_RESULT_MAX_CHARS: int = 8_000
+
+
+def truncate_tool_result(
+    result: str,
+    max_chars: int = DEFAULT_TOOL_RESULT_MAX_CHARS,
+) -> str:
+    """Truncate a tool result that exceeds max_chars.
+
+    Extends the same pattern as `_truncate_context_text` in nodes.py but
+    uses a single-sided cut (keep the beginning) since tool results are
+    typically most relevant at the start (file headers, match context, etc.).
+
+    Appends a clear marker so the agent knows content was dropped.
+    """
+    if len(result) <= max_chars:
+        return result
+    kept = result[:max_chars]
+    dropped = len(result) - max_chars
+    return (
+        kept
+        + f"\n\n[... {dropped:,} chars truncated"
+        " — use read_file with line ranges for full content ...]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Message-history compression
+# ---------------------------------------------------------------------------
+
+# Trigger compression when context reaches this fraction of the model limit.
+CONTEXT_WARN_FRACTION: float = 0.75
+
+# Always keep at least this many recent messages intact (never compressed).
+CONTEXT_KEEP_RECENT: int = 6
+
+# Max chars of each message included in the compression prompt.
+_COMPRESS_MSG_PREVIEW: int = 600
+
+
+def compress_messages(
+    messages: list,
+    model: str,
+    llm: object,
+) -> list:
+    """Compress old messages to free context space.
+
+    Strategy:
+    1. Keep the SystemMessage(s) at the head — these contain instructions.
+    2. Keep the last CONTEXT_KEEP_RECENT messages — these are the live context.
+    3. Summarise everything in between into a single compact HumanMessage.
+
+    The summary is produced by the same LLM that is currently running
+    (mirrors the `_compress_memory_file` pattern in nodes.py).
+
+    Returns the new, shorter message list. If there is nothing to compress
+    (too few messages) the original list is returned unchanged.
+    """
+    system_msgs = [m for m in messages if isinstance(m, SystemMessage)]
+    non_system  = [m for m in messages if not isinstance(m, SystemMessage)]
+
+    # Need at least CONTEXT_KEEP_RECENT + 1 non-system messages to compress
+    if len(non_system) <= CONTEXT_KEEP_RECENT + 1:
+        return messages
+
+    tail   = non_system[-CONTEXT_KEEP_RECENT:]
+    middle = non_system[:-CONTEXT_KEEP_RECENT]
+
+    # Build a text representation of the middle turns
+    middle_text_parts: list[str] = []
+    for msg in middle:
+        role_name = type(msg).__name__.replace("Message", "")
+        content = getattr(msg, "content", "") or ""
+        if isinstance(content, list):
+            content = " ".join(
+                c.get("text", "") if isinstance(c, dict) else str(c)
+                for c in content
+            )
+        preview = str(content)[:_COMPRESS_MSG_PREVIEW]
+        if len(str(content)) > _COMPRESS_MSG_PREVIEW:
+            preview += "…"
+        middle_text_parts.append(f"[{role_name}]: {preview}")
+
+    middle_text = "\n\n".join(middle_text_parts)
+
+    summary_prompt = (
+        "Summarise the following conversation turns into a compact context block.\n"
+        "Preserve: decisions made, files changed, errors encountered, current task state.\n"
+        "Be concise — max 400 words. Do not add commentary.\n\n"
+        f"{middle_text}"
+    )
+
+    try:
+        summary_response = llm.invoke([HumanMessage(content=summary_prompt)])  # type: ignore[union-attr]
+        summary_text = (
+            summary_response.content
+            if hasattr(summary_response, "content")
+            else str(summary_response)
+        )
+    except Exception:
+        # Compression failed — return original rather than crashing the workflow
+        return messages
+
+    compressed = HumanMessage(
+        content=(
+            f"[CONTEXT SUMMARY — {len(middle)} turns compressed]\n\n"
+            f"{summary_text}"
+        )
+    )
+
+    return system_msgs + [compressed] + tail

--- a/app/core/events.py
+++ b/app/core/events.py
@@ -54,6 +54,7 @@ class EventCategory(str, Enum):
     AGENT_TOKEN = "agent_token"     # streaming token chunk
     AGENT_RESPONSE = "agent_response"   # final visible conversational reply
     TOKEN_USAGE = "token_usage"         # per-call token/cost metrics
+    CONTEXT_USAGE = "context_usage"     # context window utilisation check
     TOOL_CALL = "tool_call"
     TOOL_RESULT = "tool_result"
     PLAN = "plan"
@@ -193,6 +194,28 @@ def emit_agent_token(agent: str, token: str) -> None:
         category=EventCategory.AGENT_TOKEN,
         agent=agent,
         title=token,
+    ))
+
+
+def emit_context_usage(
+    agent: str,
+    estimated_tokens: int,
+    model_limit: int,
+    fraction: float,
+    compressed: bool = False,
+) -> None:
+    """Emit a context-window utilisation event."""
+    suffix = " → compressed" if compressed else ""
+    emit(WorkflowEvent(
+        category=EventCategory.CONTEXT_USAGE,
+        agent=agent,
+        title=f"📊 Context: {fraction:.0%} ({estimated_tokens:,} / {model_limit:,} tok){suffix}",
+        metadata={
+            "estimated_tokens": estimated_tokens,
+            "model_limit":       model_limit,
+            "fraction":          round(fraction, 3),
+            "compressed":        compressed,
+        },
     ))
 
 

--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -102,6 +102,11 @@
   .cost-btn.cost-soft  { background: var(--yellow-dim); color: var(--yellow); border-color: var(--yellow); }
   .cost-btn.cost-hard  { background: var(--red-dim);    color: var(--red);    border-color: var(--red);    animation: pulse 1s infinite; }
 
+  /* Context window indicator button */
+  .ctx-btn { font-variant-numeric: tabular-nums; min-width: 68px; }
+  .ctx-btn.ctx-warn { background: var(--yellow-dim); color: var(--yellow); border-color: var(--yellow); }
+  .ctx-btn.ctx-high { background: var(--red-dim);    color: var(--red);    border-color: var(--red); }
+
   /* Cost breakdown modal */
   .cost-modal {
     position: fixed; inset: 0; background: rgba(0,0,0,.6);
@@ -497,7 +502,8 @@
   <div class="header-status">
     <span class="progress-text" id="progressText">—</span>
     <span class="badge badge-idle" id="badge">IDLE</span>
-    <button class="intel-btn cost-btn" id="costBtn" onclick="toggleCostModal()" title="Token budget & cost breakdown" style="display:none">💰 $0.0000</button>
+    <button class="intel-btn ctx-btn" id="ctxBtn" title="Context window usage" style="display:none">📊 0%</button>
+    <button class="intel-btn cost-btn" id="costBtn" onclick="toggleCostModal()" title="Token budget &amp; cost breakdown" style="display:none">💰 $0.0000</button>
     <button class="intel-btn" id="intelBtn" onclick="toggleIntel()" title="Code Intelligence Dashboard">🧠 Intel</button>
   </div>
 </header>
@@ -590,6 +596,27 @@ function addUser(text) {
   div.textContent = text;
   chat.appendChild(div);
   scrollBottom();
+}
+
+// ── Context window indicator ──────────────────────────────
+function updateContextIndicator(eventData) {
+  const meta = eventData.metadata || {};
+  const fraction = meta.fraction ?? 0;
+  const pct = Math.round(fraction * 100);
+
+  const btn = document.getElementById('ctxBtn');
+  if (!btn) return;
+  btn.style.display = '';
+  btn.textContent = `📊 ${pct}%`;
+
+  btn.classList.remove('ctx-warn', 'ctx-high');
+  if (fraction >= 0.75)      btn.classList.add('ctx-high');
+  else if (fraction >= 0.50) btn.classList.add('ctx-warn');
+
+  // Update tooltip with details
+  const estTok = (meta.estimated_tokens ?? 0).toLocaleString();
+  const limTok = (meta.model_limit ?? 0).toLocaleString();
+  btn.title = `Context: ${pct}% (${estTok} / ${limTok} tokens)${meta.compressed ? ' — compressed' : ''}`;
 }
 
 // ── Token budget / cost tracking ─────────────────────────
@@ -1182,6 +1209,11 @@ function handleEvent(evt) {
     case 'token_usage':
       // Update cost indicator in header
       updateCostIndicator(data);
+      break;
+
+    case 'context_usage':
+      // Update context window indicator in header
+      updateContextIndicator(data);
       break;
 
     case 'agent_think':

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -1,0 +1,337 @@
+"""Tests for context window management (Issue #36).
+
+Covers:
+- estimate_tokens / estimate_messages_tokens: basic correctness
+- context_limit_for_model: known models, prefix matching, unknown fallback, Ollama
+- context_usage_fraction: proportion calculation
+- truncate_tool_result: short (no-op), long (truncated with marker), exact boundary
+- compress_messages: no-op when too few messages, compresses middle, keeps head+tail
+- compress_messages: returns original on LLM failure
+- CONTEXT_WARN_FRACTION / CONTEXT_KEEP_RECENT constants present
+- Config: context_warn_fraction, context_keep_recent_messages, tool_result_max_chars
+- EventCategory.CONTEXT_USAGE present; emit_context_usage emits correct metadata
+- _invoke_agent integration: tool results are truncated (mock check)
+- _invoke_agent integration: context warning emitted when fraction > 0.5 initially
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from langchain_core.messages import HumanMessage, SystemMessage, AIMessage, ToolMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ai_msg(content: str) -> AIMessage:
+    m = AIMessage(content=content)
+    m.tool_calls = []
+    return m
+
+
+# ---------------------------------------------------------------------------
+# 1. estimate_tokens / estimate_messages_tokens
+# ---------------------------------------------------------------------------
+
+class TestEstimateTokens:
+    def test_empty_string_returns_one(self):
+        from app.core.context_window import estimate_tokens
+        assert estimate_tokens("") == 1
+
+    def test_short_text(self):
+        from app.core.context_window import estimate_tokens
+        # 30 chars / 3.0 = 10 tokens
+        assert estimate_tokens("a" * 30) == 10
+
+    def test_longer_text_scales(self):
+        from app.core.context_window import estimate_tokens
+        t300 = estimate_tokens("x" * 300)
+        t600 = estimate_tokens("x" * 600)
+        assert t600 == t300 * 2
+
+    def test_estimate_messages_single(self):
+        from app.core.context_window import estimate_messages_tokens, estimate_tokens
+        msg = HumanMessage(content="hello world")
+        total = estimate_messages_tokens([msg])
+        # should be estimate_tokens("hello world") + 4 overhead
+        expected = estimate_tokens("hello world") + 4
+        assert total == expected
+
+    def test_estimate_messages_multiple(self):
+        from app.core.context_window import estimate_messages_tokens
+        msgs = [HumanMessage(content="hello"), AIMessage(content="world")]
+        t1 = estimate_messages_tokens([msgs[0]])
+        t2 = estimate_messages_tokens([msgs[1]])
+        combined = estimate_messages_tokens(msgs)
+        assert combined == t1 + t2
+
+    def test_estimate_messages_empty_list(self):
+        from app.core.context_window import estimate_messages_tokens
+        assert estimate_messages_tokens([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. context_limit_for_model
+# ---------------------------------------------------------------------------
+
+class TestContextLimitForModel:
+    def _limit(self, model):
+        from app.core.context_window import context_limit_for_model
+        return context_limit_for_model(model)
+
+    def test_gpt4o_mini_exact_match(self):
+        assert self._limit("gpt-4o-mini") == 128_000
+
+    def test_claude_sonnet_exact_match(self):
+        assert self._limit("claude-sonnet-4-20250514") == 200_000
+
+    def test_prefix_match_claude_variant(self):
+        # A variant not in the table but prefix-matchable
+        limit = self._limit("claude-sonnet-4-20250514-preview")
+        assert limit == 200_000
+
+    def test_gpt4_8k(self):
+        assert self._limit("gpt-4") == 8_192
+
+    def test_unknown_model_default(self):
+        limit = self._limit("some-unknown-model-xyz-v99")
+        from app.core.context_window import MODEL_CONTEXT_LIMITS
+        assert limit == MODEL_CONTEXT_LIMITS["_default"]
+
+    def test_ollama_model_uses_ollama_default(self):
+        from app.core.context_window import MODEL_CONTEXT_LIMITS
+        assert self._limit("ollama:llama3.1:70b") == MODEL_CONTEXT_LIMITS["_ollama"]
+
+    def test_slash_model_treated_as_ollama(self):
+        from app.core.context_window import MODEL_CONTEXT_LIMITS
+        assert self._limit("meta/llama-3") == MODEL_CONTEXT_LIMITS["_ollama"]
+
+
+# ---------------------------------------------------------------------------
+# 3. context_usage_fraction
+# ---------------------------------------------------------------------------
+
+class TestContextUsageFraction:
+    def test_small_messages_fraction_below_one(self):
+        from app.core.context_window import context_usage_fraction
+        msgs = [HumanMessage(content="hi")]
+        f = context_usage_fraction(msgs, "gpt-4o-mini")
+        assert 0.0 < f < 1.0
+
+    def test_fraction_scales_with_message_size(self):
+        from app.core.context_window import context_usage_fraction
+        short = [HumanMessage(content="hi")]
+        long_ = [HumanMessage(content="x" * 50_000)]
+        f_short = context_usage_fraction(short, "gpt-4o-mini")
+        f_long  = context_usage_fraction(long_, "gpt-4o-mini")
+        assert f_long > f_short
+
+    def test_fraction_uses_model_limit(self):
+        from app.core.context_window import context_usage_fraction
+        msgs = [HumanMessage(content="x" * 3_000)]
+        f_large_ctx = context_usage_fraction(msgs, "claude-sonnet-4-20250514")   # 200k
+        f_small_ctx = context_usage_fraction(msgs, "gpt-4")                      # 8k
+        assert f_small_ctx > f_large_ctx
+
+
+# ---------------------------------------------------------------------------
+# 4. truncate_tool_result
+# ---------------------------------------------------------------------------
+
+class TestTruncateToolResult:
+    def test_short_result_unchanged(self):
+        from app.core.context_window import truncate_tool_result
+        text = "hello world"
+        assert truncate_tool_result(text, max_chars=100) == text
+
+    def test_exact_limit_unchanged(self):
+        from app.core.context_window import truncate_tool_result
+        text = "x" * 100
+        assert truncate_tool_result(text, max_chars=100) == text
+
+    def test_long_result_truncated(self):
+        from app.core.context_window import truncate_tool_result
+        text = "x" * 200
+        result = truncate_tool_result(text, max_chars=100)
+        assert len(result) < len(text)
+        assert result.startswith("x" * 100)
+
+    def test_truncation_marker_appended(self):
+        from app.core.context_window import truncate_tool_result
+        result = truncate_tool_result("x" * 200, max_chars=100)
+        assert "truncated" in result.lower()
+
+    def test_truncation_reports_dropped_chars(self):
+        from app.core.context_window import truncate_tool_result
+        result = truncate_tool_result("x" * 200, max_chars=100)
+        assert "100" in result  # 200 - 100 = 100 chars dropped
+
+    def test_default_limit_used_when_none_provided(self):
+        from app.core.context_window import truncate_tool_result, DEFAULT_TOOL_RESULT_MAX_CHARS
+        short = "x" * (DEFAULT_TOOL_RESULT_MAX_CHARS - 1)
+        assert truncate_tool_result(short) == short
+
+    def test_empty_string_unchanged(self):
+        from app.core.context_window import truncate_tool_result
+        assert truncate_tool_result("", max_chars=100) == ""
+
+
+# ---------------------------------------------------------------------------
+# 5. compress_messages
+# ---------------------------------------------------------------------------
+
+class TestCompressMessages:
+    def _make_msgs(self, n_middle: int, keep: int = 6):
+        """Build a message list: 1 SystemMessage + n_middle + keep messages."""
+        msgs = [SystemMessage(content="You are a helpful assistant.")]
+        for i in range(n_middle):
+            msgs.append(HumanMessage(content=f"Message {i}: " + "x" * 100))
+        for i in range(keep):
+            msgs.append(AIMessage(content=f"Recent {i}"))
+        return msgs
+
+    def _mock_llm(self, summary: str = "Summary of old turns."):
+        llm = MagicMock()
+        response = MagicMock()
+        response.content = summary
+        llm.invoke.return_value = response
+        return llm
+
+    def test_too_few_messages_returns_unchanged(self):
+        from app.core.context_window import compress_messages, CONTEXT_KEEP_RECENT
+        msgs = [SystemMessage(content="sys"), HumanMessage(content="hi")]
+        llm = self._mock_llm()
+        result = compress_messages(msgs, "gpt-4o-mini", llm)
+        assert result is msgs
+        llm.invoke.assert_not_called()
+
+    def test_compress_reduces_message_count(self):
+        from app.core.context_window import compress_messages
+        msgs = self._make_msgs(n_middle=10)
+        original_count = len(msgs)
+        llm = self._mock_llm()
+        result = compress_messages(msgs, "gpt-4o-mini", llm)
+        assert len(result) < original_count
+
+    def test_system_message_preserved(self):
+        from app.core.context_window import compress_messages
+        msgs = self._make_msgs(n_middle=10)
+        llm = self._mock_llm()
+        result = compress_messages(msgs, "gpt-4o-mini", llm)
+        assert any(isinstance(m, SystemMessage) for m in result)
+
+    def test_recent_messages_preserved(self):
+        from app.core.context_window import compress_messages, CONTEXT_KEEP_RECENT
+        msgs = self._make_msgs(n_middle=10, keep=CONTEXT_KEEP_RECENT)
+        recent_contents = {m.content for m in msgs[-CONTEXT_KEEP_RECENT:]}
+        llm = self._mock_llm()
+        result = compress_messages(msgs, "gpt-4o-mini", llm)
+        result_contents = {m.content for m in result}
+        assert recent_contents.issubset(result_contents)
+
+    def test_summary_message_has_context_prefix(self):
+        from app.core.context_window import compress_messages
+        msgs = self._make_msgs(n_middle=10)
+        llm = self._mock_llm("This is the summary.")
+        result = compress_messages(msgs, "gpt-4o-mini", llm)
+        summary_msgs = [m for m in result if "CONTEXT SUMMARY" in (m.content or "")]
+        assert len(summary_msgs) == 1
+
+    def test_llm_called_once_for_summary(self):
+        from app.core.context_window import compress_messages
+        msgs = self._make_msgs(n_middle=10)
+        llm = self._mock_llm()
+        compress_messages(msgs, "gpt-4o-mini", llm)
+        assert llm.invoke.call_count == 1
+
+    def test_llm_failure_returns_original(self):
+        from app.core.context_window import compress_messages
+        msgs = self._make_msgs(n_middle=10)
+        llm = MagicMock()
+        llm.invoke.side_effect = RuntimeError("LLM unavailable")
+        result = compress_messages(msgs, "gpt-4o-mini", llm)
+        assert result is msgs  # original returned, not raised
+
+
+# ---------------------------------------------------------------------------
+# 6. Constants
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_context_warn_fraction_between_zero_and_one(self):
+        from app.core.context_window import CONTEXT_WARN_FRACTION
+        assert 0.0 < CONTEXT_WARN_FRACTION < 1.0
+
+    def test_context_keep_recent_positive(self):
+        from app.core.context_window import CONTEXT_KEEP_RECENT
+        assert CONTEXT_KEEP_RECENT > 0
+
+    def test_default_tool_result_max_chars_positive(self):
+        from app.core.context_window import DEFAULT_TOOL_RESULT_MAX_CHARS
+        assert DEFAULT_TOOL_RESULT_MAX_CHARS > 0
+
+
+# ---------------------------------------------------------------------------
+# 7. Config fields
+# ---------------------------------------------------------------------------
+
+class TestConfigFields:
+    def test_context_warn_fraction_default(self):
+        from app.core.config import get_settings
+        assert get_settings().context_warn_fraction == 0.75
+
+    def test_context_keep_recent_messages_default(self):
+        from app.core.config import get_settings
+        assert get_settings().context_keep_recent_messages == 6
+
+    def test_tool_result_max_chars_default(self):
+        from app.core.config import get_settings
+        assert get_settings().tool_result_max_chars == 8_000
+
+
+# ---------------------------------------------------------------------------
+# 8. Events
+# ---------------------------------------------------------------------------
+
+class TestContextUsageEvent:
+    def _clear(self):
+        import app.core.events as ev
+        ev.clear_listeners()
+        ev._history.clear()
+
+    def test_context_usage_in_event_category(self):
+        from app.core.events import EventCategory
+        assert hasattr(EventCategory, "CONTEXT_USAGE")
+        assert EventCategory.CONTEXT_USAGE == "context_usage"
+
+    def test_emit_context_usage_emits_event(self):
+        from app.core.events import emit_context_usage, get_history
+        self._clear()
+        emit_context_usage("coder_a", 10_000, 128_000, 0.078)
+        history = get_history()
+        matching = [e for e in history if e.get("category") == "context_usage"]
+        assert len(matching) == 1
+        self._clear()
+
+    def test_emit_context_usage_metadata(self):
+        from app.core.events import emit_context_usage, get_history
+        self._clear()
+        emit_context_usage("tester", 50_000, 200_000, 0.25, compressed=True)
+        history = get_history()
+        evt = next(e for e in history if e.get("category") == "context_usage")
+        assert evt["metadata"]["estimated_tokens"] == 50_000
+        assert evt["metadata"]["model_limit"] == 200_000
+        assert evt["metadata"]["compressed"] is True
+        self._clear()
+
+    def test_emit_context_usage_title_contains_percent(self):
+        from app.core.events import emit_context_usage, get_history
+        self._clear()
+        emit_context_usage("planner", 25_000, 128_000, 0.195)
+        history = get_history()
+        evt = next(e for e in history if e.get("category") == "context_usage")
+        assert "%" in evt.get("title", "")
+        self._clear()


### PR DESCRIPTION
… indicator

Prevents context-overflow crashes and silent quality degradation during long tool-call loops. Two-layer protection inside _invoke_agent(): preventive (truncation) and reactive (LLM compression).

Extends the existing _truncate_context_text / _compress_memory_file patterns to the live all_messages list rather than adding new concepts.

New file — app/core/context_window.py:
- CHARS_PER_TOKEN = 3.0: conservative chars/token heuristic, no tiktoken needed
- estimate_tokens(text): max(1, int(len(text) / CHARS_PER_TOKEN))
- estimate_messages_tokens(messages): sum of per-message estimates + 4 overhead
- MODEL_CONTEXT_LIMITS: known input-window sizes for all used models (Anthropic 200k, GPT-4o 128k, GPT-4 8k, etc.). Prefix-matched.
- context_limit_for_model(model): prefix matching + Ollama + _default fallback
- context_usage_fraction(messages, model): estimated / limit → 0.0–1.0+
- DEFAULT_TOOL_RESULT_MAX_CHARS = 8_000
- truncate_tool_result(result, max_chars): keeps beginning, appends '[... N chars truncated — use read_file with line ranges ...]' marker. Extends the _truncate_context_text pattern to dynamic tool results.
- CONTEXT_WARN_FRACTION = 0.75, CONTEXT_KEEP_RECENT = 6
- compress_messages(messages, model, llm): keeps SystemMessage head + last 6 messages, summarises middle turns via LLM (same pattern as _compress_memory_file). Returns original list on LLM failure (never raises).

app/core/config.py:
- context_warn_fraction: float = 0.75  (CONTEXT_WARN_FRACTION env var)
- context_keep_recent_messages: int = 6  (CONTEXT_KEEP_RECENT_MESSAGES)
- tool_result_max_chars: int = 8_000   (TOOL_RESULT_MAX_CHARS)

app/core/events.py:
- EventCategory.CONTEXT_USAGE = 'context_usage'
- emit_context_usage(agent, estimated_tokens, model_limit, fraction, compressed)

app/core/nodes.py — three integration points in _invoke_agent():
  (a) Before tool loop: warn via emit_status if initial context fraction > 50%
  (b) Tool results: truncate_tool_result() applied before ToolMessage appended
      to all_messages (replaces the bare str(result) append)
  (c) After each LLM response: estimate context, emit_context_usage event,
      call compress_messages() if fraction >= settings.context_warn_fraction,
      emit before/after status messages and context_usage events
  settings = get_settings() cached at top of function (was fetched per-call)

app/web/server.py:
- StatusResponse.context_usage: dict = {} (new field)
- _context_usage_summary: module-level tracker updated by _broadcast_event when category == 'context_usage'. Tracks compressed_count across the run.
- GET /api/status now includes context_usage with estimated_tokens, model_limit, fraction, compressed_count.

app/web/static/index.html:
- 📊 ctx-btn added to header bar (hidden until first context_usage event). Updates on every event. Colours: neutral → yellow (≥50%) → red (≥75%). Tooltip shows token counts and model limit.
- CSS: .ctx-btn, .ctx-btn.ctx-warn, .ctx-btn.ctx-high
- JS: updateContextIndicator(), case 'context_usage' in handleEvent()

tests/test_context_window.py (new, 40 tests):
  - estimate_tokens / estimate_messages_tokens correctness
  - context_limit_for_model: exact, prefix, unknown fallback, Ollama
  - context_usage_fraction: proportionality, model-dependent
  - truncate_tool_result: no-op, truncation, marker, boundary, empty
  - compress_messages: too-few no-op, count reduction, system preserved, tail preserved, summary prefix, LLM call count, failure safety
  - Constants: CONTEXT_WARN_FRACTION, CONTEXT_KEEP_RECENT ranges
  - Config: three new settings defaults
  - Events: CONTEXT_USAGE category, emit metadata shape

Before: tool-call loops had unbounded all_messages growth; one large
  read_file call could consume 30%+ of context silently.
After:  tool results capped at 8k chars; context tracked and compressed
  at 75% threshold; live 📊 indicator in UI header.

Closes #36