### PR TITLE
feat(core): coder question confidence threshold — urgency + auto-proc…

### DIFF
--- a/app/agents/prompts/coder_a.txt
+++ b/app/agents/prompts/coder_a.txt
@@ -78,15 +78,24 @@ In these rare cases you may pause and ask the human INSTEAD of guessing.
     "Redis (distributed, persistent)",
     "In-process LRU (simple, zero-latency)",
     "Decide for me — use whichever fits best"
-  ]
+  ],
+  "urgency": "advisory",
+  "default_if_skipped": "I will use in-process LRU as it matches the existing codebase patterns."
 }
 ```
+
+**`urgency` field (required):**
+- `"blocking"` — cannot proceed without the human's answer. Use for decisions that produce fundamentally different implementations: schema choices, API contract breaks, destructive operations. The system will always ask the human.
+- `"advisory"` — you have a sensible default but the human might prefer otherwise: naming choices, cache strategies, retry policies, minor UX preferences. Always provide `default_if_skipped`. The system may skip the question and use your default automatically.
+
+**`default_if_skipped` field (required for advisory questions):**
+Write a complete, actionable sentence describing exactly what you will do if the question is skipped. Example: "I will use in-process LRU as it matches the existing codebase patterns."
 
 Rules:
 - The JSON must be the **entire** response — no preamble, no code, no explanation.
 - `options` is optional; omit it for fully open-ended questions.
-- The system will inject the human's answer into your next invocation.
-- You will then continue implementing with the answer in context.
+- The system will inject the human's answer (or the default assumption) into your next invocation.
+- You will then continue implementing with that context.
 
 
 Your response must include:

--- a/app/agents/prompts/coder_b.txt
+++ b/app/agents/prompts/coder_b.txt
@@ -78,15 +78,24 @@ In these rare cases you may pause and ask the human INSTEAD of guessing.
     "Redis (distributed, persistent)",
     "In-process LRU (simple, zero-latency)",
     "Decide for me — use whichever fits best"
-  ]
+  ],
+  "urgency": "advisory",
+  "default_if_skipped": "I will use in-process LRU as it matches the existing codebase patterns."
 }
 ```
+
+**`urgency` field (required):**
+- `"blocking"` — cannot proceed without the human's answer. Use for decisions that produce fundamentally different implementations: schema choices, API contract breaks, destructive operations. The system will always ask the human.
+- `"advisory"` — you have a sensible default but the human might prefer otherwise: naming choices, cache strategies, retry policies, minor UX preferences. Always provide `default_if_skipped`. The system may skip the question and use your default automatically.
+
+**`default_if_skipped` field (required for advisory questions):**
+Write a complete, actionable sentence describing exactly what you will do if the question is skipped. Example: "I will use in-process LRU as it matches the existing codebase patterns."
 
 Rules:
 - The JSON must be the **entire** response — no preamble, no code, no explanation.
 - `options` is optional; omit it for fully open-ended questions.
-- The system will inject the human's answer into your next invocation.
-- You will then continue implementing with the answer in context.
+- The system will inject the human's answer (or the default assumption) into your next invocation.
+- You will then continue implementing with that context.
 
 
 Your response must include:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -76,6 +76,13 @@ class Settings(BaseSettings):
     max_iterations_per_item: int = 5
     max_rework_cycles_per_item: int = 3
     shell_timeout_seconds: int = 120
+
+    # ── Coder question threshold ───────────────────────────────────────
+    # Controls when agents may interrupt the human with a clarifying question.
+    coder_question_max_per_item: int = 1
+    # "ask"          → advisory questions are forwarded to the human (default, existing behaviour)
+    # "auto_proceed" → advisory questions are skipped; coder uses default_if_skipped assumption
+    coder_question_advisory_mode: str = "ask"
     max_output_chars: int = 12_000
 
     # Token budget / cost limits (USD). Set to 0.0 to disable.

--- a/app/core/events.py
+++ b/app/core/events.py
@@ -396,20 +396,28 @@ def emit_coder_question(
     context: str = "",
     options: list | None = None,
     item_id: str = "",
+    urgency: str = "blocking",
+    default_if_skipped: str = "",
 ) -> None:
     """Emit when a coder agent pauses mid-item to ask the human a critical question.
 
     Args:
-        asked_by:  The coder role (``"coder_a"`` or ``"coder_b"``).
-        question:  The question text the human must answer.
-        context:   Why the coder is asking (architectural context, trade-offs, etc.).
-        options:   Suggested answer choices (may be empty for open-ended questions).
-        item_id:   The current work item ID for traceability.
+        asked_by:           The coder role (``"coder_a"`` or ``"coder_b"``).
+        question:           The question text the human must answer.
+        context:            Why the coder is asking (architectural context, trade-offs, etc.).
+        options:            Suggested answer choices (may be empty for open-ended questions).
+        item_id:            The current work item ID for traceability.
+        urgency:            ``"blocking"`` (cannot proceed without answer) or
+                            ``"advisory"`` (has a sensible default to fall back on).
+        default_if_skipped: What the coder will do if the question is skipped.
+                            Only meaningful when ``urgency="advisory"``.
     """
+    urgency_safe = urgency if urgency in ("blocking", "advisory") else "blocking"
+    urgency_icon = "🔴" if urgency_safe == "blocking" else "🟡"
     emit(WorkflowEvent(
         category=EventCategory.CODER_QUESTION,
         agent=asked_by,
-        title=f"🤔 {asked_by} is asking a question",
+        title=f"{urgency_icon} {asked_by} is asking a question",
         detail=question,
         metadata={
             "question": question,
@@ -417,6 +425,9 @@ def emit_coder_question(
             "options": options or [],
             "asked_by": asked_by,
             "item_id": item_id,
+            "urgency": urgency_safe,
+            "urgency_icon": urgency_icon,
+            "default_if_skipped": default_if_skipped,
         },
     ))
 

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -36,6 +36,7 @@ class TodoItem(BaseModel):
     iteration_count: int = 0
     rework_count: int = 0
     test_fail_count: int = 0
+    coder_questions_asked: int = 0   # number of ask_human signals emitted for this item
 
 
 class WorkflowPhase(StrEnum):
@@ -89,6 +90,8 @@ class GraphState(BaseModel):
     coder_question_options: list[str] = Field(default_factory=list)  # suggested choices
     coder_question_asked_by: str = ""  # "coder_a" | "coder_b"
     coder_question_answer: str = ""    # human's answer (filled by UI/Telegram)
+    coder_question_urgency: str = "blocking"   # "blocking" | "advisory"
+    coder_question_default: str = ""           # default_if_skipped text (advisory only)
 
     # ── Plan Approval Gate (between planner and coder) ────────────────
     # The workflow halts at plan_approval_gate_node after planning until

--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -335,11 +335,29 @@
   .question-header .q-icon { font-size: 18px; }
   .question-header .q-title {
     flex: 1; font-size: 13px; font-weight: 700; color: var(--purple); letter-spacing: 0.5px;
-  }
-  .question-header .q-agent {
+  }  .question-header .q-agent {
     font-size: 10px; padding: 2px 8px; border-radius: 8px;
     background: #2a1a40; color: #c084fc; font-weight: 700; text-transform: uppercase;
   }
+  .question-header .q-urgency-badge {
+    font-size: 10px; padding: 2px 7px; border-radius: 8px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.3px;
+  }
+  .urgency-blocking { background: #3a1010; color: #f87171; }
+  .urgency-advisory { background: #2a1e00; color: #fbbf24; }
+  .question-default-hint {
+    margin-top: 6px; font-size: 11px; color: var(--text-faint); font-style: italic;
+    padding: 5px 10px; background: var(--surface2); border-radius: 4px;
+    border-left: 2px solid #fbbf24;
+  }
+  .btn-skip {
+    align-self: flex-end; padding: 8px 14px; background: transparent;
+    border: 1px solid var(--border-light); color: var(--text-dim); border-radius: 5px;
+    font-family: var(--font); font-size: 11px; font-weight: 700; cursor: pointer;
+    transition: opacity 0.15s, border-color 0.15s;
+  }
+  .btn-skip:hover { border-color: #fbbf24; color: #fbbf24; }
+  .btn-skip:disabled { opacity: 0.4; cursor: default; }
   .question-body { padding: 14px 16px; border-bottom: 1px solid #2a1a40; }
   .question-text {
     font-size: 13px; color: var(--text); line-height: 1.6; margin-bottom: 0;
@@ -1179,34 +1197,50 @@ function showQuestionPanel(meta) {
   const panel = document.createElement('div');
   panel.className = 'question-panel';
 
-  const agentLabel = meta.asked_by === 'coder_a' ? 'CODER A · Claude' : 'CODER B · GPT';
+  const agentLabel  = meta.asked_by === 'coder_a' ? 'CODER A · Claude' : 'CODER B · GPT';
+  const urgency     = meta.urgency || 'blocking';
+  const isAdvisory  = urgency === 'advisory';
+  const urgencyText = isAdvisory ? '🟡 ADVISORY' : '🔴 BLOCKING';
+  const urgencyCls  = isAdvisory ? 'urgency-advisory' : 'urgency-blocking';
+  const default_    = meta.default_if_skipped || '';
 
   const contextHtml = meta.context
     ? `<div class="question-context">${esc(meta.context)}</div>` : '';
 
-  const options = meta.options || [];
+  const defaultHintHtml = (isAdvisory && default_)
+    ? `<div class="question-default-hint">If skipped: ${esc(default_)}</div>` : '';
+
+  const options    = meta.options || [];
   const optionsHtml = options.length
     ? `<div class="question-options">
         <div class="opt-label">Quick answers</div>
         ${options.map((o, i) => `<button class="btn-option" data-idx="${i}">${esc(o)}</button>`).join('')}
       </div>` : '';
 
+  const skipBtnHtml = isAdvisory
+    ? `<button class="btn-skip" id="btnSkip" title="Skip question and proceed with stated default">⚡ Skip — use default</button>` : '';
+
   panel.innerHTML = `
     <div class="question-header">
       <span class="q-icon">🤔</span>
       <span class="q-title">CODER IS ASKING</span>
+      <span class="q-urgency-badge ${urgencyCls}">${urgencyText}</span>
       <span class="q-agent">${esc(agentLabel)}</span>
     </div>
     <div class="question-body">
       <div class="question-text">${esc(meta.question)}</div>
       ${contextHtml}
+      ${defaultHintHtml}
     </div>
     ${optionsHtml}
     <div class="question-freetext">
       <div class="question-freetext-inner">
         <div class="ft-label">Custom answer</div>
         <input type="text" id="answerInput" placeholder="Type your answer…" autocomplete="off" />
-        <button class="btn-answer" id="btnAnswer">SEND</button>
+        <div style="display:flex;gap:8px;justify-content:flex-end">
+          ${skipBtnHtml}
+          <button class="btn-answer" id="btnAnswer">SEND</button>
+        </div>
       </div>
     </div>`;
 
@@ -1218,6 +1252,12 @@ function showQuestionPanel(meta) {
   panel.querySelectorAll('.btn-option').forEach(btn => {
     btn.addEventListener('click', () => submitAnswer(btn.textContent.trim(), panel));
   });
+
+  // Skip button (advisory only)
+  const skipBtn = panel.querySelector('#btnSkip');
+  if (skipBtn) {
+    skipBtn.addEventListener('click', () => submitAnswer('__skip__', panel));
+  }
 
   // Free-text send
   panel.querySelector('#btnAnswer').addEventListener('click', () => {


### PR DESCRIPTION
…eed logic

Coders can now classify each ask_human question as 'blocking' or 'advisory'. The system uses this to decide whether to interrupt the human or proceed automatically with a stated default assumption.

State (app/core/state.py):
- TodoItem.coder_questions_asked: int = 0  (per-item counter)
- GraphState.coder_question_urgency: str = 'blocking'
- GraphState.coder_question_default: str = ''

Config (app/core/config.py):
- coder_question_max_per_item: int = 1
- coder_question_advisory_mode: str = 'ask'  ('ask' | 'auto_proceed')

Events (app/core/events.py):
- emit_coder_question: +urgency, +default_if_skipped, +urgency_icon Title now shows 🔴 (blocking) or 🟡 (advisory)

Nodes (app/core/nodes.py):
- _parse_coder_question: extracts urgency + default_if_skipped Unknown urgency values default to 'blocking' (safe)
- coder_node: threshold logic replaces old binary ask/no-ask · advisory + auto_proceed mode  → skip, re-invoke with assumption
  · any question + cap reached    → skip, re-invoke with assumption
  · otherwise                     → ask human (existing behaviour)
  · coder_questions_asked incremented on both ask AND skip
  · urgency/default stored in GraphState when asking
- answer_gate_node: handles '__skip__' sentinel
  · replaces sentinel with coder_question_default (or generic fallback)
  · emits '⚡ Human chose to skip' status event
  · resets coder_question_urgency/default on answer delivery

Web UI (app/web/static/index.html):
- Question panel shows urgency badge (🔴 BLOCKING / 🟡 ADVISORY)
- Advisory questions show 'If skipped: <default>' hint below text
- Advisory questions show '⚡ Skip — use default' button Clicking it sends '__skip__' sentinel to /api/answer

Prompts (app/agents/prompts/coder_a.txt, coder_b.txt):
- ask_human schema extended with 'urgency' and 'default_if_skipped'
- Full field documentation with when-to-use guidance
- Example uses urgency='advisory' with a concrete default_if_skipped

Default config preserves existing behaviour:
  max_per_item=1, advisory_mode='ask' → no change for existing tasks. Operators can set advisory_mode='auto_proceed' for full autonomy.

Tests: 33 new tests in tests/test_coder_question_threshold.py
Full suite: 762 passed / 0 failed

Closes #40