### PR TITLE
fix(ui): token cost button always visible and synced from /api/status

### DIFF
--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -600,7 +600,7 @@
     <span class="progress-text" id="progressText">—</span>
     <span class="badge badge-idle" id="badge">IDLE</span>
     <button class="intel-btn ctx-btn" id="ctxBtn" title="Context window usage" style="display:none">📊 0%</button>
-    <button class="intel-btn cost-btn" id="costBtn" onclick="toggleCostModal()" title="Token budget &amp; cost breakdown" style="display:none">💰 $0.0000</button>
+    <button class="intel-btn cost-btn" id="costBtn" onclick="toggleCostModal()" title="Token budget &amp; cost breakdown">💰 $0.0000</button>
     <button class="intel-btn" id="intelBtn" onclick="toggleIntel()" title="Code Intelligence Dashboard">🧠 Intel</button>
   </div>
 </header>
@@ -749,7 +749,7 @@ function toggleCostModal() {
 function renderCostModal() {
   const body = document.getElementById('costModalBody');
   if (!_costData && _totalCostUsd === 0) {
-    body.innerHTML = '<p style="color:var(--text-dim);text-align:center">No token data recorded yet.</p>';
+    body.innerHTML = '<p style="color:var(--text-dim);text-align:center;padding:24px 0">No token usage recorded yet.<br><span style="font-size:11px">Costs appear here after the first LLM call.</span></p>';
     return;
   }
 
@@ -1479,8 +1479,29 @@ function updateHeader(data) {
   );
   if (data.completed !== undefined) {
     progressText.textContent = `${data.completed}/${data.total || '?'} items · ${data.branch || ''}`;
+  } else if (data.items_done !== undefined) {
+    progressText.textContent = `${data.items_done}/${data.items_total || '?'} items · ${data.branch || ''}`;
   } else if (data.progress) {
     progressText.textContent = data.progress;
+  }
+
+  // Sync token budget from /api/status response
+  const budget = data.token_budget;
+  if (budget && typeof budget === 'object') {
+    const costUsd = budget.total_cost_usd ?? 0;
+    const totalTok = budget.total_tokens ?? 0;
+    if (costUsd > 0 || totalTok > 0) {
+      _costData = budget;
+      _totalCostUsd = costUsd;
+      const btn = document.getElementById('costBtn');
+      if (btn) {
+        btn.style.display = '';
+        btn.textContent = `💰 $${costUsd.toFixed(4)}`;
+        btn.classList.remove('cost-soft', 'cost-hard');
+        if (budget.hard_limit_hit) btn.classList.add('cost-hard');
+        else if (budget.soft_limit_hit) btn.classList.add('cost-soft');
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Previously the 💰 cost button was hidden (display:none) and only appeared when a live token_usage WebSocket event fired in the current browser session. Reconnecting, refreshing, or opening a second tab would hide it again even if a task was actively running.

Changes:
- Cost button no longer starts as display:none — it's always visible in the toolbar showing $0.0000 until real data arrives
- updateHeader() now reads token_budget from /api/status responses and updates the button label and colour state (soft/hard limits) on every status poll (initial load + 5-second interval fallback)
- Fixed progress text to handle both 'completed/total' and 'items_done/items_total' field naming from the status endpoint
- Cost modal empty state shows a clearer message when no task has run

No backend changes — the token_budget field was already returned by GET /api/status; the frontend just wasn't reading it.