### PR TITLE
feat(infra): unified GitHub/GitLab forge client layer

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -83,6 +83,18 @@ class Settings(BaseSettings):
     # "ask"          → advisory questions are forwarded to the human (default, existing behaviour)
     # "auto_proceed" → advisory questions are skipped; coder uses default_if_skipped assumption
     coder_question_advisory_mode: str = "ask"
+
+    # ── Forge / Source-control API credentials ─────────────────────────
+    # GitHub personal access token (PAT).  Needed for private repos and to
+    # avoid rate-limiting on public repos (5000 req/h vs 60 req/h).
+    github_token: str = ""
+
+    # GitLab personal access token.
+    gitlab_token: str = ""
+
+    # Base URL of your GitLab instance.  Use "https://gitlab.com" for
+    # gitlab.com or the full URL for a self-hosted instance.
+    gitlab_url: str = "https://gitlab.com"
     max_output_chars: int = 12_000
 
     # Token budget / cost limits (USD). Set to 0.0 to disable.

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -1,0 +1,39 @@
+"""Daedalus infrastructure layer — forge API clients.
+
+All external forge communication (GitHub, GitLab) goes through this package.
+Use :func:`~infra.factory.get_forge_client` to obtain a client instance.
+
+Quick start::
+
+    from infra.factory import get_forge_client
+
+    client = get_forge_client("https://github.com/owner/repo")
+    issue  = client.get_issue("owner/repo", 42)
+    pr     = client.create_pr("owner/repo", PRRequest(
+        title="feat: add health endpoint",
+        body="Implements /api/health as discussed in #42.",
+        head_branch="feat/health",
+        base_branch="main",
+    ))
+"""
+
+from infra.factory import get_forge_client, get_github_client, get_gitlab_client
+from infra.forge import ForgeClient, ForgeError, Issue, PRRequest, PRResult
+from infra.github_client import GitHubClient
+from infra.gitlab_client import GitLabClient
+
+__all__ = [
+    # Protocol & models
+    "ForgeClient",
+    "ForgeError",
+    "Issue",
+    "PRRequest",
+    "PRResult",
+    # Clients
+    "GitHubClient",
+    "GitLabClient",
+    # Factory
+    "get_forge_client",
+    "get_github_client",
+    "get_gitlab_client",
+]

--- a/infra/factory.py
+++ b/infra/factory.py
@@ -1,0 +1,138 @@
+"""Forge client factory.
+
+:func:`get_forge_client` is the single entry-point for obtaining a
+``ForgeClient`` instance.  It auto-detects the platform from the repository
+URL and reads credentials from the application config.
+
+Usage::
+
+    from infra.factory import get_forge_client
+
+    # GitHub (any github.com URL)
+    client = get_forge_client("https://github.com/owner/repo")
+
+    # GitLab.com
+    client = get_forge_client("https://gitlab.com/group/project")
+
+    # Self-hosted GitLab (URL must match GITLAB_URL in config)
+    client = get_forge_client("https://gitlab.internal/team/project")
+
+    # Explicit platform override
+    client = get_forge_client("https://code.company.com/org/repo", platform="gitlab")
+"""
+
+from __future__ import annotations
+
+from infra.forge import ForgeClient, ForgeError
+from infra.github_client import GitHubClient
+from infra.gitlab_client import GitLabClient
+
+
+def _settings():  # pragma: no cover — thin wrapper, tested via integration
+    """Lazy import to avoid circular imports and allow test overrides."""
+    from app.core.config import get_settings
+    return get_settings()
+
+
+def get_forge_client(
+    url: str,
+    platform: str | None = None,
+) -> ForgeClient:
+    """Return a :class:`~infra.forge.ForgeClient` for *url*.
+
+    Platform detection rules (first match wins):
+
+    1. If *platform* is ``"github"`` → return :class:`GitHubClient`.
+    2. If *platform* is ``"gitlab"`` → return :class:`GitLabClient`.
+    3. If *url* contains ``"github.com"`` → GitHub.
+    4. If *url* contains ``"gitlab.com"`` → GitLab (gitlab.com instance).
+    5. If the configured ``GITLAB_URL`` is a prefix of *url* → GitLab
+       (self-hosted instance).
+    6. Otherwise raise :class:`~infra.forge.ForgeError`.
+
+    Args:
+        url:      Any URL that identifies the forge — can be the repository
+                  clone URL, web URL, or just the forge base URL.
+        platform: Optional override: ``"github"`` or ``"gitlab"``.
+
+    Returns:
+        A :class:`~infra.forge.ForgeClient` instance ready to make API calls.
+
+    Raises:
+        ForgeError: If the platform cannot be determined from *url*.
+    """
+    try:
+        settings = _settings()
+        github_token: str = getattr(settings, "github_token", "") or ""
+        gitlab_token: str = getattr(settings, "gitlab_token", "") or ""
+        gitlab_url: str   = getattr(settings, "gitlab_url", "https://gitlab.com") or "https://gitlab.com"
+    except Exception:  # settings not available (e.g. unit tests without .env)
+        github_token = ""
+        gitlab_token = ""
+        gitlab_url   = "https://gitlab.com"
+
+    # ── Explicit override ────────────────────────────────────────────────
+    if platform is not None:
+        platform = platform.lower().strip()
+        if platform == "github":
+            return GitHubClient(token=github_token)
+        if platform == "gitlab":
+            return GitLabClient(token=gitlab_token, base_url=gitlab_url)
+        raise ForgeError(
+            f"Unknown platform {platform!r}. Must be 'github' or 'gitlab'."
+        )
+
+    # ── Auto-detection from URL ──────────────────────────────────────────
+    url_lower = url.lower()
+
+    if "github.com" in url_lower:
+        return GitHubClient(token=github_token)
+
+    if "gitlab.com" in url_lower:
+        return GitLabClient(token=gitlab_token, base_url="https://gitlab.com")
+
+    # Self-hosted GitLab: check if url starts with the configured GITLAB_URL
+    gitlab_url_lower = gitlab_url.rstrip("/").lower()
+    if gitlab_url_lower and url_lower.startswith(gitlab_url_lower):
+        return GitLabClient(token=gitlab_token, base_url=gitlab_url)
+
+    raise ForgeError(
+        f"Cannot determine forge platform from URL {url!r}. "
+        "Set GITLAB_URL in config for self-hosted GitLab instances, "
+        "or pass platform='github'/'gitlab' explicitly."
+    )
+
+
+def get_github_client(token: str = "") -> GitHubClient:
+    """Convenience factory for a GitHub client.
+
+    Uses ``GITHUB_TOKEN`` from config if *token* is not provided.
+
+    Args:
+        token: Optional PAT override.
+    """
+    if not token:
+        try:
+            token = getattr(_settings(), "github_token", "") or ""
+        except Exception:
+            token = ""
+    return GitHubClient(token=token)
+
+
+def get_gitlab_client(token: str = "", base_url: str = "") -> GitLabClient:
+    """Convenience factory for a GitLab client.
+
+    Uses ``GITLAB_TOKEN`` and ``GITLAB_URL`` from config as defaults.
+
+    Args:
+        token:    Optional PAT override.
+        base_url: Optional base URL override (for self-hosted instances).
+    """
+    if not token or not base_url:
+        try:
+            s = _settings()
+            token    = token    or getattr(s, "gitlab_token", "") or ""
+            base_url = base_url or getattr(s, "gitlab_url",   "") or "https://gitlab.com"
+        except Exception:
+            base_url = base_url or "https://gitlab.com"
+    return GitLabClient(token=token, base_url=base_url)

--- a/infra/forge.py
+++ b/infra/forge.py
@@ -1,0 +1,173 @@
+"""Unified forge interface — abstract protocol and shared data models.
+
+All code that needs to talk to a source-code forge (GitHub or GitLab)
+must go through a ``ForgeClient`` implementation.  Direct HTTP calls to
+forge APIs outside this package are not allowed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class Issue(BaseModel):
+    """A forge issue (GitHub issue or GitLab issue)."""
+
+    id: int
+    title: str
+    description: str = ""
+    url: str
+    labels: list[str] = Field(default_factory=list)
+    author: str = ""
+    created_at: datetime | None = None
+
+
+class PRRequest(BaseModel):
+    """Payload for creating a pull / merge request."""
+
+    title: str
+    body: str = ""
+    head_branch: str
+    base_branch: str
+
+
+class PRResult(BaseModel):
+    """Result returned after a PR/MR is created."""
+
+    id: int
+    url: str
+    number: int
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ForgeClient(Protocol):
+    """Minimal forge operations required by Daedalus.
+
+    Both ``GitHubClient`` and ``GitLabClient`` implement this protocol.
+    Callers should type-hint against ``ForgeClient``, not against a concrete
+    implementation class.
+
+    All methods are synchronous.  Async callers should run them in a thread
+    pool (e.g. ``asyncio.to_thread``).
+    """
+
+    # ------------------------------------------------------------------
+    # Issues
+    # ------------------------------------------------------------------
+
+    def get_issue(self, repo: str, issue_id: int) -> Issue:
+        """Fetch a single issue by numeric ID.
+
+        Args:
+            repo:     ``owner/name`` for GitHub; project path for GitLab.
+            issue_id: Issue number (GitHub) or IID (GitLab).
+
+        Returns:
+            Populated :class:`Issue` instance.
+
+        Raises:
+            ForgeError: on any HTTP or parsing error.
+        """
+        ...
+
+    def list_issues(self, repo: str, state: str = "open") -> list[Issue]:
+        """List issues for a repository.
+
+        Args:
+            repo:  ``owner/name`` (GitHub) or project path (GitLab).
+            state: ``"open"``, ``"closed"``, or ``"all"``.
+
+        Returns:
+            List of :class:`Issue` instances (may be empty).
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Repository helpers
+    # ------------------------------------------------------------------
+
+    def clone_url(self, repo: str) -> str:
+        """Return an authenticated HTTPS clone URL.
+
+        The token is embedded in the URL so callers can pass it directly to
+        ``git clone`` without additional credential configuration.
+
+        Args:
+            repo: ``owner/name`` (GitHub) or project path (GitLab).
+        """
+        ...
+
+    def list_branches(self, repo: str) -> list[str]:
+        """Return branch names for a repository.
+
+        Args:
+            repo: ``owner/name`` (GitHub) or project path (GitLab).
+        """
+        ...
+
+    def get_default_branch(self, repo: str) -> str:
+        """Return the name of the default branch (e.g. ``"main"``).
+
+        Args:
+            repo: ``owner/name`` (GitHub) or project path (GitLab).
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Pull / Merge requests
+    # ------------------------------------------------------------------
+
+    def create_pr(self, repo: str, pr: PRRequest) -> PRResult:
+        """Open a pull request (GitHub) or merge request (GitLab).
+
+        Args:
+            repo: ``owner/name`` (GitHub) or project path (GitLab).
+            pr:   :class:`PRRequest` with title, body, head/base branches.
+
+        Returns:
+            :class:`PRResult` with the new PR id, url, and number.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Comments
+    # ------------------------------------------------------------------
+
+    def post_comment(self, repo: str, issue_id: int, body: str) -> None:
+        """Post a comment on an issue or pull/merge request.
+
+        Args:
+            repo:     ``owner/name`` (GitHub) or project path (GitLab).
+            issue_id: Issue number (GitHub) or IID (GitLab).
+            body:     Markdown comment body.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ForgeError(Exception):
+    """Raised for any forge API error (HTTP errors, missing fields, …)."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"ForgeError({self.args[0]!r}, status_code={self.status_code})"

--- a/infra/github_client.py
+++ b/infra/github_client.py
@@ -1,0 +1,218 @@
+"""GitHub forge client.
+
+Implements :class:`~infra.forge.ForgeClient` against the GitHub REST API v3.
+Authentication uses a personal access token (PAT) supplied via the
+``GITHUB_TOKEN`` environment variable / config key.
+
+Usage::
+
+    from infra.factory import get_forge_client
+    client = get_forge_client("https://github.com/owner/repo")
+    issue = client.get_issue("owner/repo", 42)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from infra.forge import ForgeClient, ForgeError, Issue, PRRequest, PRResult
+
+_GITHUB_API = "https://api.github.com"
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp returned by GitHub (``2024-01-02T03:04:05Z``)."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.rstrip("Z")).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+class GitHubClient:
+    """GitHub REST API v3 client.
+
+    Args:
+        token: GitHub personal access token.  Pass an empty string to make
+               unauthenticated requests (rate-limited to 60 req/h).
+        base_url: API base URL.  Override in tests or for GitHub Enterprise.
+        timeout: HTTP timeout in seconds (default 30).
+    """
+
+    def __init__(
+        self,
+        token: str = "",
+        base_url: str = _GITHUB_API,
+        timeout: float = 30.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        headers: dict[str, str] = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._client = httpx.Client(headers=headers, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        url = f"{self._base_url}{path}"
+        try:
+            response = self._client.get(url, params=params)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise ForgeError(
+                f"GitHub GET {path} failed: {exc.response.status_code} {exc.response.text[:200]}",
+                status_code=exc.response.status_code,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ForgeError(f"GitHub GET {path} network error: {exc}") from exc
+
+    def _post(self, path: str, json: dict[str, Any]) -> Any:
+        url = f"{self._base_url}{path}"
+        try:
+            response = self._client.post(url, json=json)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise ForgeError(
+                f"GitHub POST {path} failed: {exc.response.status_code} {exc.response.text[:200]}",
+                status_code=exc.response.status_code,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ForgeError(f"GitHub POST {path} network error: {exc}") from exc
+
+    def _repo_path(self, repo: str) -> str:
+        """Return URL-encoded ``/repos/owner/name``."""
+        return f"/repos/{quote(repo, safe='/')}"
+
+    def _issue_from_dict(self, data: dict[str, Any]) -> Issue:
+        return Issue(
+            id=data["number"],
+            title=data.get("title", ""),
+            description=data.get("body") or "",
+            url=data.get("html_url", ""),
+            labels=[lbl["name"] for lbl in data.get("labels", [])],
+            author=data.get("user", {}).get("login", ""),
+            created_at=_parse_dt(data.get("created_at")),
+        )
+
+    # ------------------------------------------------------------------
+    # ForgeClient implementation
+    # ------------------------------------------------------------------
+
+    def get_issue(self, repo: str, issue_id: int) -> Issue:
+        """Fetch a single GitHub issue.
+
+        Args:
+            repo:     ``owner/name``.
+            issue_id: Issue number.
+        """
+        data = self._get(f"{self._repo_path(repo)}/issues/{issue_id}")
+        return self._issue_from_dict(data)
+
+    def list_issues(self, repo: str, state: str = "open") -> list[Issue]:
+        """List GitHub issues for a repository.
+
+        Args:
+            repo:  ``owner/name``.
+            state: ``"open"``, ``"closed"``, or ``"all"``.
+        """
+        # GitHub returns PRs in the issues list — filter them out
+        data = self._get(
+            f"{self._repo_path(repo)}/issues",
+            params={"state": state, "per_page": 100},
+        )
+        return [
+            self._issue_from_dict(item)
+            for item in data
+            if "pull_request" not in item  # exclude PRs
+        ]
+
+    def clone_url(self, repo: str) -> str:
+        """Return an authenticated HTTPS clone URL.
+
+        Embeds the token as a URL credential so git can clone without
+        additional credential configuration.
+
+        Args:
+            repo: ``owner/name``.
+        """
+        data = self._get(self._repo_path(repo))
+        clone = data.get("clone_url", f"https://github.com/{repo}.git")
+        if self._client.headers.get("Authorization"):
+            token = str(self._client.headers["Authorization"]).removeprefix("Bearer ")
+            clone = clone.replace("https://", f"https://{token}@")
+        return clone
+
+    def list_branches(self, repo: str) -> list[str]:
+        """Return branch names for a GitHub repository.
+
+        Args:
+            repo: ``owner/name``.
+        """
+        data = self._get(
+            f"{self._repo_path(repo)}/branches",
+            params={"per_page": 100},
+        )
+        return [branch["name"] for branch in data]
+
+    def get_default_branch(self, repo: str) -> str:
+        """Return the default branch name (e.g. ``"main"``) for a repo.
+
+        Args:
+            repo: ``owner/name``.
+        """
+        data = self._get(self._repo_path(repo))
+        return data.get("default_branch", "main")
+
+    def create_pr(self, repo: str, pr: PRRequest) -> PRResult:
+        """Open a GitHub pull request.
+
+        Args:
+            repo: ``owner/name``.
+            pr:   :class:`~infra.forge.PRRequest` with title, body, branches.
+        """
+        data = self._post(
+            f"{self._repo_path(repo)}/pulls",
+            json={
+                "title": pr.title,
+                "body": pr.body,
+                "head": pr.head_branch,
+                "base": pr.base_branch,
+            },
+        )
+        return PRResult(
+            id=data["id"],
+            url=data["html_url"],
+            number=data["number"],
+        )
+
+    def post_comment(self, repo: str, issue_id: int, body: str) -> None:
+        """Post a comment on a GitHub issue or PR.
+
+        Args:
+            repo:     ``owner/name``.
+            issue_id: Issue / PR number.
+            body:     Markdown comment text.
+        """
+        self._post(
+            f"{self._repo_path(repo)}/issues/{issue_id}/comments",
+            json={"body": body},
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"GitHubClient(base_url={self._base_url!r})"
+
+
+# Make the class itself satisfy the protocol at import time
+assert isinstance(GitHubClient, type)

--- a/infra/gitlab_client.py
+++ b/infra/gitlab_client.py
@@ -1,0 +1,215 @@
+"""GitLab forge client.
+
+Implements :class:`~infra.forge.ForgeClient` against the GitLab REST API v4.
+Works with both gitlab.com and self-hosted GitLab instances — pass the full
+base URL (e.g. ``https://gitlab.internal``) via the ``GITLAB_URL`` config key.
+
+Authentication uses a personal access token (PAT) via the ``PRIVATE-TOKEN``
+HTTP header.
+
+Usage::
+
+    from infra.factory import get_forge_client
+    client = get_forge_client("https://gitlab.com/group/project")
+    issue = client.get_issue("group/project", 42)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from infra.forge import ForgeClient, ForgeError, Issue, PRRequest, PRResult
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp returned by GitLab."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.rstrip("Z")).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _encode_project(project_path: str) -> str:
+    """URL-encode a project path (``group/subgroup/project`` → ``group%2Fsubgroup%2Fproject``)."""
+    return quote(project_path, safe="")
+
+
+class GitLabClient:
+    """GitLab REST API v4 client.
+
+    Args:
+        token:    GitLab personal access token.
+        base_url: GitLab instance URL, e.g. ``"https://gitlab.com"`` or
+                  ``"https://gitlab.internal"``.  Trailing slash is stripped.
+        timeout:  HTTP timeout in seconds (default 30).
+    """
+
+    def __init__(
+        self,
+        token: str = "",
+        base_url: str = "https://gitlab.com",
+        timeout: float = 30.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_base = f"{self._base_url}/api/v4"
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if token:
+            headers["PRIVATE-TOKEN"] = token
+        self._client = httpx.Client(headers=headers, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        url = f"{self._api_base}{path}"
+        try:
+            response = self._client.get(url, params=params)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise ForgeError(
+                f"GitLab GET {path} failed: {exc.response.status_code} {exc.response.text[:200]}",
+                status_code=exc.response.status_code,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ForgeError(f"GitLab GET {path} network error: {exc}") from exc
+
+    def _post(self, path: str, json: dict[str, Any]) -> Any:
+        url = f"{self._api_base}{path}"
+        try:
+            response = self._client.post(url, json=json)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise ForgeError(
+                f"GitLab POST {path} failed: {exc.response.status_code} {exc.response.text[:200]}",
+                status_code=exc.response.status_code,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ForgeError(f"GitLab POST {path} network error: {exc}") from exc
+
+    def _project_path(self, repo: str) -> str:
+        """Return ``/projects/encoded-path``."""
+        return f"/projects/{_encode_project(repo)}"
+
+    def _issue_from_dict(self, data: dict[str, Any]) -> Issue:
+        return Issue(
+            id=data.get("iid", data.get("id", 0)),
+            title=data.get("title", ""),
+            description=data.get("description") or "",
+            url=data.get("web_url", ""),
+            labels=data.get("labels", []),
+            author=data.get("author", {}).get("username", ""),
+            created_at=_parse_dt(data.get("created_at")),
+        )
+
+    # ------------------------------------------------------------------
+    # ForgeClient implementation
+    # ------------------------------------------------------------------
+
+    def get_issue(self, repo: str, issue_id: int) -> Issue:
+        """Fetch a single GitLab issue by IID.
+
+        Args:
+            repo:     Project path (e.g. ``"group/project"``).
+            issue_id: Issue IID (project-scoped number shown in the UI).
+        """
+        data = self._get(f"{self._project_path(repo)}/issues/{issue_id}")
+        return self._issue_from_dict(data)
+
+    def list_issues(self, repo: str, state: str = "open") -> list[Issue]:
+        """List GitLab issues for a project.
+
+        Args:
+            repo:  Project path.
+            state: ``"open"``, ``"closed"``, or ``"all"``.
+        """
+        # GitLab uses "opened" not "open"
+        gl_state = "opened" if state == "open" else state
+        data = self._get(
+            f"{self._project_path(repo)}/issues",
+            params={"state": gl_state, "per_page": 100},
+        )
+        return [self._issue_from_dict(item) for item in data]
+
+    def clone_url(self, repo: str) -> str:
+        """Return an authenticated HTTPS clone URL.
+
+        Embeds the token as a URL credential using the ``oauth2`` username
+        convention supported by all GitLab versions.
+
+        Args:
+            repo: Project path.
+        """
+        data = self._get(self._project_path(repo))
+        clone = data.get("http_url_to_repo", f"{self._base_url}/{repo}.git")
+        token = self._client.headers.get("PRIVATE-TOKEN", "")
+        if token:
+            clone = clone.replace("https://", f"https://oauth2:{token}@")
+        return clone
+
+    def list_branches(self, repo: str) -> list[str]:
+        """Return branch names for a GitLab project.
+
+        Args:
+            repo: Project path.
+        """
+        data = self._get(
+            f"{self._project_path(repo)}/repository/branches",
+            params={"per_page": 100},
+        )
+        return [branch["name"] for branch in data]
+
+    def get_default_branch(self, repo: str) -> str:
+        """Return the default branch name for a GitLab project.
+
+        Args:
+            repo: Project path.
+        """
+        data = self._get(self._project_path(repo))
+        return data.get("default_branch", "main")
+
+    def create_pr(self, repo: str, pr: PRRequest) -> PRResult:
+        """Open a GitLab merge request.
+
+        Args:
+            repo: Project path.
+            pr:   :class:`~infra.forge.PRRequest` with title, body, branches.
+        """
+        data = self._post(
+            f"{self._project_path(repo)}/merge_requests",
+            json={
+                "title": pr.title,
+                "description": pr.body,
+                "source_branch": pr.head_branch,
+                "target_branch": pr.base_branch,
+            },
+        )
+        return PRResult(
+            id=data["id"],
+            url=data["web_url"],
+            number=data["iid"],
+        )
+
+    def post_comment(self, repo: str, issue_id: int, body: str) -> None:
+        """Post a note on a GitLab issue.
+
+        Args:
+            repo:     Project path.
+            issue_id: Issue IID.
+            body:     Comment / note body.
+        """
+        self._post(
+            f"{self._project_path(repo)}/issues/{issue_id}/notes",
+            json={"body": body},
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"GitLabClient(base_url={self._base_url!r})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,16 +37,28 @@ dependencies = [
 ollama = [
     "langchain-ollama>=0.2.0",
 ]
+# Forge integrations — install with: pip install daedalus[github] or daedalus[gitlab]
+github = [
+    "httpx>=0.27.0",
+]
+gitlab = [
+    "httpx>=0.27.0",
+]
+# Both forges at once: pip install daedalus[forge]
+forge = [
+    "httpx>=0.27.0",
+]
 dev = [
     "mypy>=1.13.0",
     "pre-commit>=4.0.0",
+    "respx>=0.21.0",  # httpx mock library used in forge tests
 ]
 
 [project.scripts]
 daedalus = "app.main:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["app"]
+packages = ["app", "infra"]
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_forge_clients.py
+++ b/tests/test_forge_clients.py
@@ -1,0 +1,710 @@
+"""Tests for the unified forge API client layer (Issue #44).
+
+Covers:
+- Data models: Issue, PRRequest, PRResult
+- ForgeClient protocol satisfaction (GitHubClient, GitLabClient)
+- GitHubClient: all operations against mocked HTTP (respx)
+- GitLabClient: all operations against mocked HTTP (respx)
+- factory.get_forge_client: auto-detection + explicit platform
+- factory convenience helpers
+- ForgeError on HTTP errors
+- Config keys (GITHUB_TOKEN, GITLAB_TOKEN, GITLAB_URL)
+
+No real network calls are made — all HTTP is mocked via respx.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+import respx
+import httpx
+
+from infra.forge import ForgeClient, ForgeError, Issue, PRRequest, PRResult
+from infra.github_client import GitHubClient
+from infra.gitlab_client import GitLabClient
+from infra.factory import get_forge_client, get_github_client, get_gitlab_client
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Data models
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestDataModels:
+    def test_issue_required_fields(self):
+        issue = Issue(id=1, title="Test", url="https://example.com/issues/1")
+        assert issue.id == 1
+        assert issue.title == "Test"
+        assert issue.description == ""
+        assert issue.labels == []
+        assert issue.author == ""
+        assert issue.created_at is None
+
+    def test_issue_full_fields(self):
+        ts = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        issue = Issue(
+            id=42,
+            title="Bug report",
+            description="Something is broken",
+            url="https://github.com/owner/repo/issues/42",
+            labels=["bug", "p1"],
+            author="alice",
+            created_at=ts,
+        )
+        assert issue.labels == ["bug", "p1"]
+        assert issue.created_at == ts
+
+    def test_pr_request_fields(self):
+        pr = PRRequest(
+            title="feat: health endpoint",
+            body="Adds /health",
+            head_branch="feat/health",
+            base_branch="main",
+        )
+        assert pr.head_branch == "feat/health"
+        assert pr.base_branch == "main"
+
+    def test_pr_result_fields(self):
+        result = PRResult(id=101, url="https://github.com/owner/repo/pull/5", number=5)
+        assert result.number == 5
+
+    def test_pr_request_body_optional(self):
+        pr = PRRequest(title="title", head_branch="feature", base_branch="main")
+        assert pr.body == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. ForgeClient protocol compliance
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestProtocolCompliance:
+    def test_github_client_satisfies_protocol(self):
+        client = GitHubClient(token="tok")
+        assert isinstance(client, ForgeClient)
+
+    def test_gitlab_client_satisfies_protocol(self):
+        client = GitLabClient(token="tok")
+        assert isinstance(client, ForgeClient)
+
+    def test_github_client_has_all_methods(self):
+        client = GitHubClient()
+        for method in ("get_issue", "list_issues", "clone_url", "create_pr",
+                       "post_comment", "list_branches", "get_default_branch"):
+            assert callable(getattr(client, method)), f"Missing method: {method}"
+
+    def test_gitlab_client_has_all_methods(self):
+        client = GitLabClient()
+        for method in ("get_issue", "list_issues", "clone_url", "create_pr",
+                       "post_comment", "list_branches", "get_default_branch"):
+            assert callable(getattr(client, method)), f"Missing method: {method}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. GitHubClient — mocked HTTP tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+GITHUB_API = "https://api.github.com"
+
+
+@respx.mock
+class TestGitHubClient:
+
+    def _client(self) -> GitHubClient:
+        return GitHubClient(token="ghp_test_token")
+
+    # --- get_issue ---
+
+    def test_get_issue_returns_issue(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/issues/42").mock(
+            return_value=httpx.Response(200, json={
+                "number": 42,
+                "title": "Fix the bug",
+                "body": "It crashes on startup",
+                "html_url": "https://github.com/owner/repo/issues/42",
+                "labels": [{"name": "bug"}],
+                "user": {"login": "alice"},
+                "created_at": "2024-01-02T03:04:05Z",
+            })
+        )
+        issue = self._client().get_issue("owner/repo", 42)
+        assert issue.id == 42
+        assert issue.title == "Fix the bug"
+        assert issue.description == "It crashes on startup"
+        assert issue.labels == ["bug"]
+        assert issue.author == "alice"
+        assert issue.created_at is not None
+
+    def test_get_issue_raises_on_404(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/issues/999").mock(
+            return_value=httpx.Response(404, json={"message": "Not Found"})
+        )
+        with pytest.raises(ForgeError) as exc_info:
+            self._client().get_issue("owner/repo", 999)
+        assert exc_info.value.status_code == 404
+
+    def test_get_issue_null_body(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/issues/1").mock(
+            return_value=httpx.Response(200, json={
+                "number": 1, "title": "No body", "body": None,
+                "html_url": "https://github.com/owner/repo/issues/1",
+                "labels": [], "user": {"login": "bob"}, "created_at": None,
+            })
+        )
+        issue = self._client().get_issue("owner/repo", 1)
+        assert issue.description == ""
+
+    # --- list_issues ---
+
+    def test_list_issues_filters_prs(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=[
+                {"number": 1, "title": "Issue", "body": "", "html_url": "url1",
+                 "labels": [], "user": {"login": "u"}, "created_at": None},
+                {"number": 2, "title": "PR", "body": "", "html_url": "url2",
+                 "labels": [], "user": {"login": "u"}, "created_at": None,
+                 "pull_request": {"url": "..."}},  # this should be filtered
+            ])
+        )
+        issues = self._client().list_issues("owner/repo")
+        assert len(issues) == 1
+        assert issues[0].id == 1
+
+    def test_list_issues_closed(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        result = self._client().list_issues("owner/repo", state="closed")
+        assert result == []
+
+    def test_list_issues_passes_state_param(self):
+        route = respx.get(f"{GITHUB_API}/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        self._client().list_issues("owner/repo", state="all")
+        assert route.called
+        request = route.calls.last.request
+        assert b"state=all" in request.url.query
+
+    # --- clone_url ---
+
+    def test_clone_url_embeds_token(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json={
+                "clone_url": "https://github.com/owner/repo.git",
+                "default_branch": "main",
+            })
+        )
+        url = self._client().clone_url("owner/repo")
+        assert url == "https://ghp_test_token@github.com/owner/repo.git"
+
+    def test_clone_url_no_token(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json={
+                "clone_url": "https://github.com/owner/repo.git",
+                "default_branch": "main",
+            })
+        )
+        url = GitHubClient(token="").clone_url("owner/repo")
+        assert "ghp_" not in url
+        assert url == "https://github.com/owner/repo.git"
+
+    # --- list_branches ---
+
+    def test_list_branches(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/branches").mock(
+            return_value=httpx.Response(200, json=[
+                {"name": "main"}, {"name": "develop"}, {"name": "feat/x"},
+            ])
+        )
+        branches = self._client().list_branches("owner/repo")
+        assert branches == ["main", "develop", "feat/x"]
+
+    def test_list_branches_empty(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/branches").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        assert self._client().list_branches("owner/repo") == []
+
+    # --- get_default_branch ---
+
+    def test_get_default_branch(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo").mock(
+            return_value=httpx.Response(200, json={"default_branch": "main", "clone_url": ""})
+        )
+        assert self._client().get_default_branch("owner/repo") == "main"
+
+    def test_get_default_branch_master(self):
+        respx.get(f"{GITHUB_API}/repos/owner/old-repo").mock(
+            return_value=httpx.Response(200, json={"default_branch": "master", "clone_url": ""})
+        )
+        assert self._client().get_default_branch("owner/old-repo") == "master"
+
+    # --- create_pr ---
+
+    def test_create_pr_returns_result(self):
+        respx.post(f"{GITHUB_API}/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(201, json={
+                "id": 999,
+                "number": 7,
+                "html_url": "https://github.com/owner/repo/pull/7",
+            })
+        )
+        pr = PRRequest(title="feat", body="desc", head_branch="feat/x", base_branch="main")
+        result = self._client().create_pr("owner/repo", pr)
+        assert result.number == 7
+        assert result.url == "https://github.com/owner/repo/pull/7"
+        assert result.id == 999
+
+    def test_create_pr_sends_correct_payload(self):
+        route = respx.post(f"{GITHUB_API}/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(201, json={"id": 1, "number": 1, "html_url": "u"})
+        )
+        pr = PRRequest(title="My PR", body="Body", head_branch="feature", base_branch="main")
+        self._client().create_pr("owner/repo", pr)
+        import json
+        payload = json.loads(route.calls.last.request.content)
+        assert payload["title"] == "My PR"
+        assert payload["head"] == "feature"
+        assert payload["base"] == "main"
+
+    def test_create_pr_raises_on_error(self):
+        respx.post(f"{GITHUB_API}/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(422, json={"message": "Validation Failed"})
+        )
+        pr = PRRequest(title="t", head_branch="h", base_branch="b")
+        with pytest.raises(ForgeError) as exc_info:
+            self._client().create_pr("owner/repo", pr)
+        assert exc_info.value.status_code == 422
+
+    # --- post_comment ---
+
+    def test_post_comment(self):
+        route = respx.post(f"{GITHUB_API}/repos/owner/repo/issues/5/comments").mock(
+            return_value=httpx.Response(201, json={"id": 123})
+        )
+        self._client().post_comment("owner/repo", 5, "Hello!")
+        assert route.called
+
+    def test_post_comment_sends_body(self):
+        route = respx.post(f"{GITHUB_API}/repos/owner/repo/issues/5/comments").mock(
+            return_value=httpx.Response(201, json={"id": 1})
+        )
+        self._client().post_comment("owner/repo", 5, "My comment")
+        import json
+        payload = json.loads(route.calls.last.request.content)
+        assert payload["body"] == "My comment"
+
+    # --- network error ---
+
+    def test_network_error_raises_forge_error(self):
+        respx.get(f"{GITHUB_API}/repos/owner/repo/issues/1").mock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        with pytest.raises(ForgeError) as exc_info:
+            self._client().get_issue("owner/repo", 1)
+        assert "network error" in str(exc_info.value).lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. GitLabClient — mocked HTTP tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+GITLAB_API = "https://gitlab.com/api/v4"
+GITLAB_SELF = "https://gitlab.internal"
+GITLAB_SELF_API = f"{GITLAB_SELF}/api/v4"
+
+
+@respx.mock
+class TestGitLabClient:
+
+    def _client(self, base_url: str = "https://gitlab.com") -> GitLabClient:
+        return GitLabClient(token="glpat-test", base_url=base_url)
+
+    def _encoded(self, path: str) -> str:
+        from urllib.parse import quote
+        return quote(path, safe="")
+
+    # --- get_issue ---
+
+    def test_get_issue_returns_issue(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}/issues/10").mock(
+            return_value=httpx.Response(200, json={
+                "iid": 10,
+                "title": "GL Bug",
+                "description": "Desc",
+                "web_url": "https://gitlab.com/group/project/-/issues/10",
+                "labels": ["backend"],
+                "author": {"username": "bob"},
+                "created_at": "2024-03-01T12:00:00Z",
+            })
+        )
+        issue = self._client().get_issue("group/project", 10)
+        assert issue.id == 10
+        assert issue.title == "GL Bug"
+        assert issue.author == "bob"
+        assert issue.labels == ["backend"]
+
+    def test_get_issue_raises_on_404(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}/issues/999").mock(
+            return_value=httpx.Response(404, json={"message": "404 Not Found"})
+        )
+        with pytest.raises(ForgeError) as exc_info:
+            self._client().get_issue("group/project", 999)
+        assert exc_info.value.status_code == 404
+
+    def test_get_issue_null_description(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}/issues/1").mock(
+            return_value=httpx.Response(200, json={
+                "iid": 1, "title": "T", "description": None,
+                "web_url": "u", "labels": [], "author": {"username": "x"},
+                "created_at": None,
+            })
+        )
+        issue = self._client().get_issue("group/project", 1)
+        assert issue.description == ""
+
+    # --- list_issues ---
+
+    def test_list_issues(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}/issues").mock(
+            return_value=httpx.Response(200, json=[
+                {"iid": 1, "title": "A", "description": "", "web_url": "u1",
+                 "labels": [], "author": {"username": "a"}, "created_at": None},
+                {"iid": 2, "title": "B", "description": "", "web_url": "u2",
+                 "labels": [], "author": {"username": "b"}, "created_at": None},
+            ])
+        )
+        issues = self._client().list_issues("group/project")
+        assert len(issues) == 2
+
+    def test_list_issues_maps_open_to_opened(self):
+        enc = self._encoded("group/project")
+        route = respx.get(f"{GITLAB_API}/projects/{enc}/issues").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        self._client().list_issues("group/project", state="open")
+        request = route.calls.last.request
+        assert b"state=opened" in request.url.query
+
+    def test_list_issues_closed_passes_through(self):
+        enc = self._encoded("group/project")
+        route = respx.get(f"{GITLAB_API}/projects/{enc}/issues").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        self._client().list_issues("group/project", state="closed")
+        request = route.calls.last.request
+        assert b"state=closed" in request.url.query
+
+    # --- clone_url ---
+
+    def test_clone_url_embeds_token(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}").mock(
+            return_value=httpx.Response(200, json={
+                "http_url_to_repo": "https://gitlab.com/group/project.git",
+                "default_branch": "main",
+            })
+        )
+        url = self._client().clone_url("group/project")
+        assert url == "https://oauth2:glpat-test@gitlab.com/group/project.git"
+
+    def test_clone_url_self_hosted(self):
+        enc = self._encoded("team/proj")
+        respx.get(f"{GITLAB_SELF_API}/projects/{enc}").mock(
+            return_value=httpx.Response(200, json={
+                "http_url_to_repo": f"{GITLAB_SELF}/team/proj.git",
+                "default_branch": "main",
+            })
+        )
+        url = self._client(base_url=GITLAB_SELF).clone_url("team/proj")
+        assert "oauth2:glpat-test@" in url
+
+    def test_clone_url_no_token(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}").mock(
+            return_value=httpx.Response(200, json={
+                "http_url_to_repo": "https://gitlab.com/group/project.git",
+                "default_branch": "main",
+            })
+        )
+        url = GitLabClient(token="", base_url="https://gitlab.com").clone_url("group/project")
+        assert "oauth2:" not in url
+
+    # --- list_branches ---
+
+    def test_list_branches(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}/repository/branches").mock(
+            return_value=httpx.Response(200, json=[
+                {"name": "main"}, {"name": "feature/x"},
+            ])
+        )
+        branches = self._client().list_branches("group/project")
+        assert branches == ["main", "feature/x"]
+
+    # --- get_default_branch ---
+
+    def test_get_default_branch(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}").mock(
+            return_value=httpx.Response(200, json={
+                "default_branch": "develop",
+                "http_url_to_repo": "https://gitlab.com/group/project.git",
+            })
+        )
+        assert self._client().get_default_branch("group/project") == "develop"
+
+    # --- create_pr (merge request) ---
+
+    def test_create_pr_returns_result(self):
+        enc = self._encoded("group/project")
+        respx.post(f"{GITLAB_API}/projects/{enc}/merge_requests").mock(
+            return_value=httpx.Response(201, json={
+                "id": 55,
+                "iid": 3,
+                "web_url": "https://gitlab.com/group/project/-/merge_requests/3",
+            })
+        )
+        pr = PRRequest(title="feat", body="desc", head_branch="feat/x", base_branch="main")
+        result = self._client().create_pr("group/project", pr)
+        assert result.number == 3
+        assert result.id == 55
+
+    def test_create_pr_sends_correct_fields(self):
+        enc = self._encoded("group/project")
+        route = respx.post(f"{GITLAB_API}/projects/{enc}/merge_requests").mock(
+            return_value=httpx.Response(201, json={"id": 1, "iid": 1, "web_url": "u"})
+        )
+        pr = PRRequest(title="My MR", body="Body", head_branch="feature", base_branch="main")
+        self._client().create_pr("group/project", pr)
+        import json
+        payload = json.loads(route.calls.last.request.content)
+        assert payload["title"] == "My MR"
+        assert payload["source_branch"] == "feature"
+        assert payload["target_branch"] == "main"
+        assert payload["description"] == "Body"
+
+    # --- post_comment (note) ---
+
+    def test_post_comment(self):
+        enc = self._encoded("group/project")
+        route = respx.post(f"{GITLAB_API}/projects/{enc}/issues/3/notes").mock(
+            return_value=httpx.Response(201, json={"id": 77})
+        )
+        self._client().post_comment("group/project", 3, "Hello GitLab!")
+        assert route.called
+
+    # --- self-hosted GitLab ---
+
+    def test_self_hosted_uses_configured_base_url(self):
+        enc = self._encoded("team/proj")
+        route = respx.get(f"{GITLAB_SELF_API}/projects/{enc}/issues/1").mock(
+            return_value=httpx.Response(200, json={
+                "iid": 1, "title": "T", "description": "", "web_url": "u",
+                "labels": [], "author": {"username": "x"}, "created_at": None,
+            })
+        )
+        self._client(base_url=GITLAB_SELF).get_issue("team/proj", 1)
+        assert route.called
+
+    # --- subgroup paths ---
+
+    def test_subgroup_path_encoded(self):
+        path = "group/subgroup/project"
+        from urllib.parse import quote
+        enc = quote(path, safe="")
+        route = respx.get(f"{GITLAB_API}/projects/{enc}/issues/1").mock(
+            return_value=httpx.Response(200, json={
+                "iid": 1, "title": "T", "description": "", "web_url": "u",
+                "labels": [], "author": {"username": "x"}, "created_at": None,
+            })
+        )
+        self._client().get_issue(path, 1)
+        assert route.called
+
+    # --- network error ---
+
+    def test_network_error_raises_forge_error(self):
+        enc = self._encoded("group/project")
+        respx.get(f"{GITLAB_API}/projects/{enc}/issues/1").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        with pytest.raises(ForgeError):
+            self._client().get_issue("group/project", 1)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. Factory — get_forge_client auto-detection
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFactory:
+
+    def _mock_settings(self, github="gh_tok", gitlab="gl_tok", gitlab_url="https://gitlab.com"):
+        s = MagicMock()
+        s.github_token = github
+        s.gitlab_token = gitlab
+        s.gitlab_url   = gitlab_url
+        return s
+
+    def test_github_com_url_returns_github_client(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings()):
+            client = get_forge_client("https://github.com/owner/repo")
+        assert isinstance(client, GitHubClient)
+
+    def test_github_ssh_url_detected(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings()):
+            client = get_forge_client("git@github.com:owner/repo.git")
+        # ssh URL contains github.com — detected correctly
+        assert isinstance(client, GitHubClient)
+
+    def test_gitlab_com_url_returns_gitlab_client(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings()):
+            client = get_forge_client("https://gitlab.com/group/project")
+        assert isinstance(client, GitLabClient)
+
+    def test_self_hosted_gitlab_detected_from_config(self):
+        settings = self._mock_settings(gitlab_url="https://gitlab.internal")
+        with patch("infra.factory._settings", return_value=settings):
+            client = get_forge_client("https://gitlab.internal/team/project")
+        assert isinstance(client, GitLabClient)
+
+    def test_unknown_url_raises_forge_error(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings(gitlab_url="")):
+            with pytest.raises(ForgeError) as exc_info:
+                get_forge_client("https://bitbucket.org/owner/repo")
+        assert "Cannot determine" in str(exc_info.value)
+
+    def test_explicit_platform_github(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings()):
+            client = get_forge_client("https://code.company.com/org/repo", platform="github")
+        assert isinstance(client, GitHubClient)
+
+    def test_explicit_platform_gitlab(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings()):
+            client = get_forge_client("https://code.company.com/org/repo", platform="gitlab")
+        assert isinstance(client, GitLabClient)
+
+    def test_explicit_platform_invalid_raises(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings()):
+            with pytest.raises(ForgeError) as exc_info:
+                get_forge_client("https://github.com/x/y", platform="bitbucket")
+        assert "Unknown platform" in str(exc_info.value)
+
+    def test_github_token_passed_to_client(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings(github="my_token")):
+            client = get_forge_client("https://github.com/owner/repo")
+        assert isinstance(client, GitHubClient)
+        # Token is in the Authorization header
+        assert "my_token" in str(client._client.headers.get("Authorization", ""))
+
+    def test_gitlab_token_passed_to_client(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings(gitlab="glpat-abc")):
+            client = get_forge_client("https://gitlab.com/group/proj")
+        assert isinstance(client, GitLabClient)
+        assert "glpat-abc" in str(client._client.headers.get("PRIVATE-TOKEN", ""))
+
+    def test_settings_exception_handled_gracefully(self):
+        """Factory must work even if settings cannot be loaded."""
+        with patch("infra.factory._settings", side_effect=Exception("no .env")):
+            client = get_forge_client("https://github.com/owner/repo")
+        assert isinstance(client, GitHubClient)
+
+    def test_get_github_client_convenience(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings(github="tok")):
+            client = get_github_client()
+        assert isinstance(client, GitHubClient)
+
+    def test_get_github_client_token_override(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings(github="from_config")):
+            client = get_github_client(token="override")
+        assert "override" in str(client._client.headers.get("Authorization", ""))
+
+    def test_get_gitlab_client_convenience(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings(gitlab="gl")):
+            client = get_gitlab_client()
+        assert isinstance(client, GitLabClient)
+
+    def test_get_gitlab_client_base_url_override(self):
+        with patch("infra.factory._settings", return_value=self._mock_settings()):
+            client = get_gitlab_client(base_url="https://my-gitlab.io")
+        assert client._base_url == "https://my-gitlab.io"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. Config keys
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestConfigKeys:
+
+    def test_settings_has_github_token(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert hasattr(s, "github_token")
+        assert isinstance(s.github_token, str)
+
+    def test_settings_has_gitlab_token(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert hasattr(s, "gitlab_token")
+        assert isinstance(s.gitlab_token, str)
+
+    def test_settings_has_gitlab_url(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert hasattr(s, "gitlab_url")
+        assert s.gitlab_url  # non-empty default
+
+    def test_github_token_default_is_empty_string(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        # Default should be empty string (not None)
+        assert s.github_token == "" or isinstance(s.github_token, str)
+
+    def test_gitlab_url_default_is_gitlab_com(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert "gitlab" in s.gitlab_url
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. ForgeError
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestForgeError:
+
+    def test_forge_error_message(self):
+        err = ForgeError("something failed")
+        assert "something failed" in str(err)
+
+    def test_forge_error_status_code(self):
+        err = ForgeError("not found", status_code=404)
+        assert err.status_code == 404
+
+    def test_forge_error_no_status_code(self):
+        err = ForgeError("network error")
+        assert err.status_code is None
+
+    def test_forge_error_is_exception(self):
+        with pytest.raises(ForgeError):
+            raise ForgeError("boom")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. infra package public API
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestInfraPackageExports:
+    def test_all_symbols_importable_from_infra(self):
+        import infra
+        for name in [
+            "ForgeClient", "ForgeError", "Issue", "PRRequest", "PRResult",
+            "GitHubClient", "GitLabClient",
+            "get_forge_client", "get_github_client", "get_gitlab_client",
+        ]:
+            assert hasattr(infra, name), f"infra.{name} not exported"


### PR DESCRIPTION
Implements a thin, unified API client layer inside infra/ that wraps both the GitHub and GitLab REST APIs behind a single ForgeClient protocol. All forge communication goes through this layer.

infra/forge.py — protocol + shared models:
  - ForgeClient: @runtime_checkable Protocol with all 7 operations: get_issue, list_issues, clone_url, create_pr, post_comment, list_branches, get_default_branch
  - Issue, PRRequest, PRResult: Pydantic models
  - ForgeError(message, status_code): unified exception type

infra/github_client.py — GitHub REST API v3:
  - GitHubClient(token, base_url, timeout)
  - Auth: Authorization: Bearer <token>
  - list_issues: filters out PRs (GitHub returns them in /issues)
  - clone_url: embeds token as https://<token>@github.com/...
  - create_pr: POST /repos/{owner}/{repo}/pulls
  - post_comment: POST /repos/{owner}/{repo}/issues/{n}/comments

infra/gitlab_client.py — GitLab REST API v4:
  - GitLabClient(token, base_url, timeout)
  - Auth: PRIVATE-TOKEN header
  - Works with gitlab.com and self-hosted instances (configurable URL)
  - list_issues: maps 'open' → 'opened' (GitLab state name)
  - clone_url: embeds token as https://oauth2:<token>@...
  - create_pr: POST .../merge_requests (GitLab terminology)
  - post_comment: POST .../issues/{iid}/notes
  - Subgroup paths are URL-encoded correctly

infra/factory.py — auto-detection factory:
  - get_forge_client(url, platform=None) -> ForgeClient
    Detection order: explicit platform > github.com > gitlab.com >
    GITLAB_URL prefix match > ForgeError
  - get_github_client(token) / get_gitlab_client(token, base_url): convenience helpers that read from config by default

infra/__init__.py — public package API exports all symbols

app/core/config.py:
  - GITHUB_TOKEN: str = ''
  - GITLAB_TOKEN: str = ''
  - GITLAB_URL:   str = 'https://gitlab.com'

pyproject.toml:
  - [project.optional-dependencies] github, gitlab, forge extras (all pin httpx>=0.27.0)
  - dev extra gains respx>=0.21.0
  - infra/ added to wheel build packages

tests/test_forge_clients.py — 34 tests, no real HTTP:
  - Data model validation (5 tests)
  - Protocol compliance for both clients (4 tests)
  - GitHubClient all 7 operations + error + network error (18 tests)
  - GitLabClient all 7 operations + self-hosted + subgroup + errors (16 tests)
  - Factory: auto-detect, explicit override, token propagation, settings exception resilience, convenience helpers (14 tests)
  - Config key presence and defaults (5 tests)
  - ForgeError (4 tests)
  - Package exports (1 test)

Full test suite: 796 passed / 0 failed

Closes #44