### PR TITLE
feat(workspace): dynamic repo loading — replace static TARGET_REPO_PATH

### DIFF
--- a/app/core/active_repo.py
+++ b/app/core/active_repo.py
@@ -1,0 +1,79 @@
+"""Per-task repository root context variable.
+
+All tools (filesystem, git, shell, build) call :func:`get_repo_root` instead
+of reading ``settings.target_repo_path`` directly.  This makes the sandbox
+root dynamic: each workflow task can operate on a different repository without
+mutating the global Settings singleton.
+
+The :class:`contextvars.ContextVar` is correctly isolated per async task, so
+future parallel task execution will also be safe.
+
+Typical call-site pattern
+-------------------------
+In ``context_loader_node`` (or any node that establishes the repo root)::
+
+    from app.core.active_repo import set_repo_root
+    set_repo_root("/path/to/cloned/repo")
+
+In tools::
+
+    from app.core.active_repo import get_repo_root
+    root = Path(get_repo_root()).resolve()
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+# ---------------------------------------------------------------------------
+# Module-level ContextVar
+# ---------------------------------------------------------------------------
+
+_repo_root_var: ContextVar[str] = ContextVar("daedalus_repo_root", default="")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def set_repo_root(path: str) -> None:
+    """Set the repository root for the current async-task context.
+
+    Args:
+        path: Absolute path to the repository root directory.
+              An empty string resets to the settings fallback.
+    """
+    _repo_root_var.set(path)
+
+
+def get_repo_root() -> str:
+    """Return the repository root for the current context.
+
+    Resolution order:
+
+    1. Value set by :func:`set_repo_root` in the current async context.
+    2. ``settings.target_repo_path`` (static env-var, backward-compat).
+    3. Empty string (callers must guard against this).
+
+    Returns:
+        Absolute path string, or ``""`` if not configured.
+    """
+    value = _repo_root_var.get("")
+    if value:
+        return value
+
+    # Lazy import to avoid circular dependency at module load time.
+    try:
+        from app.core.config import get_settings
+        return get_settings().target_repo_path or ""
+    except Exception:
+        return ""
+
+
+def clear_repo_root() -> None:
+    """Reset the context variable to the empty default.
+
+    Useful in tests to ensure isolation between test cases.
+    """
+    _repo_root_var.set("")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -58,12 +58,25 @@ class Settings(BaseSettings):
     web_host: str = "127.0.0.1"
     web_port: int = 8420
 
-    # Target repo
+    # Target repo — static override; takes precedence over WorkspaceManager
     target_repo_path: str = ""
 
     @field_validator("target_repo_path")
     @classmethod
     def _resolve_repo(cls, value: str) -> str:
+        if value:
+            return str(Path(value).expanduser().resolve())
+        return value
+
+    # Dynamic workspace — repos are cloned here on-demand when TARGET_REPO_PATH
+    # is not set.  Mirrors the forge host/owner/name hierarchy, e.g.:
+    #   ~/daedalus-workspace/github.com/owner/repo
+    #   ~/daedalus-workspace/gitlab.internal/team/project
+    daedalus_workspace_dir: str = "~/daedalus-workspace"
+
+    @field_validator("daedalus_workspace_dir")
+    @classmethod
+    def _resolve_workspace(cls, value: str) -> str:
         if value:
             return str(Path(value).expanduser().resolve())
         return value

--- a/app/core/memory.py
+++ b/app/core/memory.py
@@ -68,8 +68,8 @@ _SEEDS = {
 # ── Core API ──────────────────────────────────────────────────────────────
 
 def _repo_root() -> Path:
-    settings = get_settings()
-    return Path(settings.target_repo_path)
+    from app.core.active_repo import get_repo_root
+    return Path(get_repo_root())
 
 
 def _memory_path(key: str) -> Path:

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -64,7 +64,8 @@ class GraphState(BaseModel):
     """The complete state passed between LangGraph nodes."""
 
     # ── Repository context ────────────────────────────────────────────
-    repo_root: str = ""
+    repo_root: str = ""        # absolute local path (set by context_loader or caller)
+    repo_ref: str = ""         # forge reference: URL or "owner/name" or "host/owner/name"
     branch_name: str = ""
 
     # ── User request ──────────────────────────────────────────────────

--- a/app/telegram/bot.py
+++ b/app/telegram/bot.py
@@ -215,12 +215,17 @@ async def cmd_task(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     global _current_state
     try:
         settings = get_settings()
+        # repo_ref may be passed as part of the task text in future; for now
+        # fall back to the static TARGET_REPO_PATH.
+        repo_path = settings.target_repo_path
+        repo_ref  = ""
         _current_state = GraphState(
             user_request=task_text,
-            repo_root=settings.target_repo_path,
+            repo_root=repo_path,
+            repo_ref=repo_ref,
             phase=WorkflowPhase.PLANNING,
         )
-        final_state = await run_workflow(task_text, settings.target_repo_path)
+        final_state = await run_workflow(task_text, repo_path, repo_ref=repo_ref)
         _current_state = final_state
 
         done  = final_state.completed_items

--- a/app/tools/build.py
+++ b/app/tools/build.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from langchain_core.tools import tool
 
-from app.core.config import get_settings
+from app.core.active_repo import get_repo_root
 from app.core.logging import get_logger
 from app.tools.terminal import run_terminal
 
@@ -35,8 +35,7 @@ def run_tests(project_type: str = "auto") -> str:
 
     project_type: 'python', 'node', 'dotnet', or 'auto' (detect).
     """
-    settings = get_settings()
-    root = settings.target_repo_path
+    root = get_repo_root()
 
     types = _detect_project_type(root) if project_type == "auto" else [project_type]
 
@@ -65,8 +64,7 @@ def run_linter(project_type: str = "auto") -> str:
 
     project_type: 'python', 'node', 'dotnet', or 'auto'.
     """
-    settings = get_settings()
-    root = settings.target_repo_path
+    root = get_repo_root()
 
     types = _detect_project_type(root) if project_type == "auto" else [project_type]
 
@@ -92,8 +90,7 @@ def run_build(project_type: str = "auto") -> str:
 
     project_type: 'python', 'node', 'dotnet', or 'auto'.
     """
-    settings = get_settings()
-    root = settings.target_repo_path
+    root = get_repo_root()
 
     types = _detect_project_type(root) if project_type == "auto" else [project_type]
 

--- a/app/tools/filesystem.py
+++ b/app/tools/filesystem.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from langchain_core.tools import tool
 
+from app.core.active_repo import get_repo_root
 from app.core.config import get_settings
 from app.core.logging import get_logger
 
@@ -21,8 +22,7 @@ class PathEscapeError(Exception):
 
 def _resolve_safe(relative_path: str) -> Path:
     """Resolve *relative_path* against repo root and verify it stays inside."""
-    settings = get_settings()
-    root = Path(settings.target_repo_path).resolve()
+    root = Path(get_repo_root()).resolve()
     if not root.exists():
         raise FileNotFoundError(f"Target repo root does not exist: {root}")
 

--- a/app/tools/git.py
+++ b/app/tools/git.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from langchain_core.tools import tool
 
+from app.core.active_repo import get_repo_root
 from app.core.config import get_settings
 from app.core.logging import get_logger
 
@@ -90,7 +91,7 @@ def _validate_git_command(command: str) -> str | None:
 def _run_git(command: str) -> str:
     """Execute a validated git command and return output."""
     settings = get_settings()
-    root = Path(settings.target_repo_path).resolve()
+    root = Path(get_repo_root()).resolve()
 
     if not root.is_dir():
         return f"ERROR: repo root does not exist: {root}"

--- a/app/tools/shell.py
+++ b/app/tools/shell.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from langchain_core.tools import tool
 
+from app.core.active_repo import get_repo_root
 from app.core.config import get_settings
 from app.core.logging import get_logger
 
@@ -77,7 +78,7 @@ def run_shell(command: str, working_dir: str = ".") -> str:
         return "DISABLED: run_shell is only enabled on non-Windows systems."
 
     settings = get_settings()
-    root = Path(settings.target_repo_path).resolve()
+    root = Path(get_repo_root()).resolve()
     cwd = (root / working_dir).resolve()
 
     if not _is_within_root(cwd, root):

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -21,6 +21,7 @@ from infra.factory import get_forge_client, get_github_client, get_gitlab_client
 from infra.forge import ForgeClient, ForgeError, Issue, PRRequest, PRResult
 from infra.github_client import GitHubClient
 from infra.gitlab_client import GitLabClient
+from infra.workspace import WorkspaceError, WorkspaceInfo, WorkspaceManager
 
 __all__ = [
     # Protocol & models
@@ -36,4 +37,8 @@ __all__ = [
     "get_forge_client",
     "get_github_client",
     "get_gitlab_client",
+    # Workspace
+    "WorkspaceManager",
+    "WorkspaceInfo",
+    "WorkspaceError",
 ]

--- a/infra/workspace.py
+++ b/infra/workspace.py
@@ -1,0 +1,384 @@
+"""Dynamic workspace manager — clone and maintain per-repo working directories.
+
+:class:`WorkspaceManager` replaces the static ``TARGET_REPO_PATH`` env var.
+Given any repo reference (URL, ``owner/name`` shorthand, or fully-qualified
+forge path), it either clones the repo on first use or pulls the latest
+changes on subsequent uses.
+
+Workspace layout::
+
+    ~/daedalus-workspace/          ← DAEDALUS_WORKSPACE_DIR
+      github.com/owner/repo-a/     ← one dir per repo
+      gitlab.com/group/project/
+      gitlab.internal/team/repo/
+
+All git operations are done via ``subprocess`` directly (not the ``git_command``
+LangChain tool) because this code runs *before* the workflow state has a
+``repo_root``, which is exactly what we are establishing here.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+from app.core.logging import get_logger
+
+logger = get_logger("infra.workspace")
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceError(Exception):
+    """Raised when a workspace operation cannot be completed."""
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkspaceInfo:
+    """Metadata about a locally cloned repository workspace."""
+
+    repo_ref: str
+    """Canonical forge reference, e.g. ``github.com/owner/repo``."""
+
+    local_path: Path
+    """Absolute path to the local clone."""
+
+    last_used: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    """Approximate time of last use (mtime of the directory)."""
+
+
+# ---------------------------------------------------------------------------
+# Reference normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalise_ref(repo_ref: str) -> tuple[str, str]:
+    """Normalise *repo_ref* to ``(canonical_key, clone_url)``.
+
+    Returns
+    -------
+    canonical_key
+        A filesystem-safe identifier like ``github.com/owner/repo`` that
+        mirrors the workspace directory structure.
+    clone_url
+        The HTTPS URL that git should clone from.  May be the same as
+        *repo_ref* if it was already a full URL.
+
+    Accepted input formats
+    ----------------------
+    - ``https://github.com/owner/repo``
+    - ``https://github.com/owner/repo.git``
+    - ``https://gitlab.com/group/subgroup/project``
+    - ``https://gitlab.internal/team/proj.git``
+    - ``owner/repo``  → treated as GitHub (github.com/owner/repo)
+    - ``github.com/owner/repo``
+    - ``gitlab.com/group/project``
+
+    Raises
+    ------
+    WorkspaceError
+        If the reference cannot be parsed into a valid forge path.
+    """
+    ref = repo_ref.strip()
+    if not ref:
+        raise WorkspaceError("repo_ref must not be empty")
+
+    # ── Full HTTPS URL ────────────────────────────────────────────────
+    if ref.startswith("http://") or ref.startswith("https://"):
+        parsed = urlparse(ref)
+        host = parsed.hostname or ""
+        path = parsed.path.strip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        parts = [p for p in path.split("/") if p]
+        if len(parts) < 2:
+            raise WorkspaceError(
+                f"URL {ref!r} does not contain at least owner/repo components"
+            )
+        canonical = f"{host}/{'/'.join(parts)}"
+        # Reconstruct a clean https URL (without .git suffix for the key)
+        clone_url = f"https://{host}/{'/'.join(parts)}.git"
+        return canonical, clone_url
+
+    # ── host/owner/repo (no scheme) ───────────────────────────────────
+    # e.g. "github.com/owner/repo" or "gitlab.internal/team/project"
+    if re.match(r"^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/", ref):
+        path = ref.rstrip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        parts = path.split("/")
+        if len(parts) < 3:
+            raise WorkspaceError(
+                f"Forge path {ref!r} must be host/owner/repo (at least 3 segments)"
+            )
+        canonical = path
+        clone_url = f"https://{path}.git"
+        return canonical, clone_url
+
+    # ── Short-form: owner/repo — assume GitHub ────────────────────────
+    parts = [p for p in ref.split("/") if p]
+    if len(parts) == 2:
+        owner, name = parts
+        canonical = f"github.com/{owner}/{name}"
+        clone_url = f"https://github.com/{owner}/{name}.git"
+        return canonical, clone_url
+
+    raise WorkspaceError(
+        f"Cannot parse repo reference {ref!r}. "
+        "Expected a full URL, 'host/owner/repo', or 'owner/repo' (GitHub shorthand)."
+    )
+
+
+def _authenticated_clone_url(canonical_key: str, plain_url: str) -> str:
+    """Return an authenticated clone URL by querying the forge client.
+
+    Falls back to the unauthenticated *plain_url* if the forge client cannot
+    be constructed (e.g. no token configured).
+
+    The forge client's ``clone_url`` method returns a URL with the token
+    embedded as a URL credential, e.g.
+    ``https://<token>@github.com/owner/repo.git``.
+    """
+    try:
+        from infra.factory import get_forge_client
+        from infra.forge import ForgeError
+
+        # Use the plain https URL for platform detection
+        client = get_forge_client(plain_url)
+
+        # The repo path for the forge API is everything after host/
+        host_slash = canonical_key.index("/")
+        repo_path = canonical_key[host_slash + 1:]
+
+        return client.clone_url(repo_path)
+    except Exception as exc:
+        logger.warning(
+            "workspace: could not get authenticated URL for %s: %s — using plain URL",
+            canonical_key,
+            exc,
+        )
+        return plain_url
+
+
+def _run_git(args: list[str], cwd: Path | None = None, timeout: int = 300) -> str:
+    """Run a git sub-command and return stdout.
+
+    Raises
+    ------
+    WorkspaceError
+        If git exits with a non-zero return code.
+    """
+    cmd = ["git"] + args
+    logger.debug("workspace git | cwd=%s | %s", cwd, " ".join(cmd))
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WorkspaceError(f"git {' '.join(args)} timed out after {timeout}s") from exc
+    except FileNotFoundError as exc:
+        raise WorkspaceError("git executable not found on PATH") from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise WorkspaceError(
+            f"git {' '.join(args[:2])} failed (exit {result.returncode}): {stderr[:400]}"
+        )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceManager
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceManager:
+    """Manage per-repo clone directories under a shared workspace root.
+
+    Args:
+        workspace_root: Root directory that will contain all cloned repos.
+                        Created automatically if it does not exist.
+    """
+
+    def __init__(self, workspace_root: Path) -> None:
+        self._root = workspace_root.expanduser().resolve()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def resolve(self, repo_ref: str) -> Path:
+        """Return the local path for *repo_ref*, cloning or pulling as needed.
+
+        Behaviour
+        ---------
+        - **Fresh clone**: If the local directory does not exist, the repo is
+          cloned using an authenticated URL from the forge client.
+        - **Existing clone**: ``git fetch origin`` → ``git checkout <default>``
+          → ``git pull --ff-only`` so the working tree is up-to-date.
+
+        Args:
+            repo_ref: URL, ``owner/name``, or ``host/owner/name``.
+
+        Returns:
+            Absolute :class:`~pathlib.Path` to the local clone.
+
+        Raises:
+            WorkspaceError: On any git failure or unparseable reference.
+        """
+        canonical, plain_url = _normalise_ref(repo_ref)
+        local_path = self._local_path(canonical)
+
+        if local_path.exists():
+            self._pull(local_path, canonical)
+        else:
+            self._clone(canonical, plain_url, local_path)
+
+        return local_path
+
+    def clean(self, repo_ref: str) -> None:
+        """Remove the local clone for *repo_ref*.
+
+        No-op if the directory does not exist.
+
+        Args:
+            repo_ref: Same formats accepted by :meth:`resolve`.
+        """
+        try:
+            canonical, _ = _normalise_ref(repo_ref)
+        except WorkspaceError:
+            logger.warning("workspace.clean: cannot parse ref %r — skipping", repo_ref)
+            return
+
+        local_path = self._local_path(canonical)
+        if local_path.exists():
+            shutil.rmtree(local_path)
+            logger.info("workspace.clean: removed %s", local_path)
+            # Remove empty parent dirs (owner/ and host/) if possible
+            for parent in (local_path.parent, local_path.parent.parent):
+                try:
+                    parent.rmdir()  # only succeeds if empty
+                except OSError:
+                    pass
+
+    def list_workspaces(self) -> list[WorkspaceInfo]:
+        """Return information about all locally cloned workspaces.
+
+        Scans ``workspace_root`` for directories that contain a ``.git``
+        sub-directory (depth ≤ 4 to match ``host/owner/name``).
+
+        Returns:
+            List of :class:`WorkspaceInfo` instances, sorted by ``local_path``.
+        """
+        if not self._root.exists():
+            return []
+
+        results: list[WorkspaceInfo] = []
+        # Walk up to 4 levels deep: host / owner / repo
+        for candidate in sorted(self._root.rglob(".git")):
+            repo_dir = candidate.parent
+            if not repo_dir.is_dir():
+                continue
+            try:
+                rel = repo_dir.relative_to(self._root)
+                ref = str(rel).replace("\\", "/")
+                mtime = datetime.fromtimestamp(repo_dir.stat().st_mtime, tz=timezone.utc)
+                results.append(WorkspaceInfo(
+                    repo_ref=ref,
+                    local_path=repo_dir,
+                    last_used=mtime,
+                ))
+            except (ValueError, OSError):
+                continue
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _local_path(self, canonical: str) -> Path:
+        """Translate a canonical key to an absolute local path."""
+        # canonical is like "github.com/owner/repo" — replace / with OS sep
+        rel = Path(*canonical.split("/"))
+        return self._root / rel
+
+    def _clone(self, canonical: str, plain_url: str, local_path: Path) -> None:
+        """Clone *plain_url* (with auth) into *local_path*."""
+        auth_url = _authenticated_clone_url(canonical, plain_url)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("workspace.clone: %s → %s", canonical, local_path)
+        _run_git(["clone", auth_url, str(local_path)])
+        logger.info("workspace.clone: done")
+
+    def _pull(self, local_path: Path, canonical: str) -> None:
+        """Bring an existing clone up-to-date (fetch + checkout default + pull)."""
+        logger.info("workspace.pull: updating %s", local_path)
+
+        # 1. Fetch all remote changes
+        try:
+            _run_git(["fetch", "origin"], cwd=local_path)
+        except WorkspaceError as exc:
+            logger.warning("workspace.pull: fetch failed: %s — continuing with local state", exc)
+            return
+
+        # 2. Determine the default branch (origin/HEAD if available)
+        default_branch = self._detect_default_branch(local_path)
+
+        # 3. Checkout default branch and fast-forward
+        try:
+            _run_git(["checkout", default_branch], cwd=local_path)
+            _run_git(["pull", "--ff-only", "origin", default_branch], cwd=local_path)
+            logger.info("workspace.pull: updated %s to latest %s", canonical, default_branch)
+        except WorkspaceError as exc:
+            logger.warning(
+                "workspace.pull: pull failed for %s: %s — using existing state",
+                canonical, exc,
+            )
+
+    def _detect_default_branch(self, local_path: Path) -> str:
+        """Return the remote default branch name, falling back to 'main'."""
+        # Try to read from origin/HEAD symbolic ref
+        for strategy in (
+            ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+            ["rev-parse", "--abbrev-ref", "origin/HEAD"],
+        ):
+            try:
+                out = _run_git(strategy, cwd=local_path)
+                # e.g. "origin/main" → "main"
+                return out.split("/", 1)[-1].strip() or "main"
+            except WorkspaceError:
+                continue
+
+        # Inspect remote branches for common default names
+        try:
+            branches_out = _run_git(
+                ["branch", "-r", "--format=%(refname:short)"], cwd=local_path
+            )
+            remote_branches = [b.strip() for b in branches_out.splitlines()]
+            for candidate in ("origin/main", "origin/master", "origin/develop"):
+                if candidate in remote_branches:
+                    return candidate.split("/", 1)[-1]
+        except WorkspaceError:
+            pass
+
+        return "main"
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"WorkspaceManager(root={self._root!r})"

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -17,10 +17,13 @@ def setup_test_repo(tmp_path):
     (tmp_path / "subdir").mkdir()
     (tmp_path / "subdir" / "nested.py").write_text("print('hello')")
 
+    from app.core.active_repo import set_repo_root, clear_repo_root
+    set_repo_root(str(tmp_path))
     with patch("app.tools.filesystem.get_settings") as mock_settings:
         mock_settings.return_value.target_repo_path = str(tmp_path)
         mock_settings.return_value.max_output_chars = 10000
         yield tmp_path
+    clear_repo_root()
 
 
 class TestResolvesSafe:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -16,12 +16,15 @@ def git_repo(tmp_path):
     subprocess.run(["git", "add", "-A"], cwd=str(tmp_path), capture_output=True)
     subprocess.run(["git", "commit", "-m", "init"], cwd=str(tmp_path), capture_output=True)
 
+    from app.core.active_repo import set_repo_root, clear_repo_root
+    set_repo_root(str(tmp_path))
     with patch("app.tools.git.get_settings") as ms:
         ms.return_value.target_repo_path = str(tmp_path)
         ms.return_value.max_output_chars = 10000
         ms.return_value.git_author_name = "test"
         ms.return_value.git_author_email = "test@test"
         yield tmp_path
+    clear_repo_root()
 
 
 class TestCommandValidation:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -12,9 +12,12 @@ import pytest
 @pytest.fixture
 def temp_repo(tmp_path):
     """Create a temporary repo directory and patch settings to use it."""
+    from app.core.active_repo import set_repo_root, clear_repo_root
+    set_repo_root(str(tmp_path))
     with patch("app.core.memory.get_settings") as mock:
         mock.return_value.target_repo_path = str(tmp_path)
         yield tmp_path
+    clear_repo_root()
 
 
 class TestEnsureMemoryFiles:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -11,6 +11,8 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="run_shell is di
 @pytest.fixture
 def mock_settings(tmp_path):
     """Mock settings pointing to a temp directory."""
+    from app.core.active_repo import set_repo_root, clear_repo_root
+    set_repo_root(str(tmp_path))
     with patch("app.tools.shell.get_settings") as ms:
         ms.return_value.target_repo_path = str(tmp_path)
         ms.return_value.max_output_chars = 10000
@@ -18,6 +20,7 @@ def mock_settings(tmp_path):
         ms.return_value.git_author_name = "test"
         ms.return_value.git_author_email = "test@test"
         yield tmp_path
+    clear_repo_root()
 
 
 class TestBlocklist:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,740 @@
+"""Tests for Issue #45 — Dynamic repo loading.
+
+Covers:
+- infra/workspace.py: WorkspaceManager (resolve, clean, list_workspaces)
+- infra/workspace.py: _normalise_ref helper
+- app/core/active_repo.py: context variable isolation
+- app/tools/* using get_repo_root() instead of settings
+- app/core/config.py: new daedalus_workspace_dir key
+- app/core/state.py: new repo_ref field
+- context_loader_node: static path unchanged / workspace path used
+- run_workflow: repo_ref forwarded to initial state
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from infra.workspace import (
+    WorkspaceError,
+    WorkspaceInfo,
+    WorkspaceManager,
+    _normalise_ref,
+    _run_git,
+)
+from app.core.active_repo import clear_repo_root, get_repo_root, set_repo_root
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+@pytest.fixture(autouse=True)
+def reset_repo_root():
+    """Ensure context var is clean before and after each test."""
+    clear_repo_root()
+    yield
+    clear_repo_root()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. _normalise_ref
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestNormaliseRef:
+
+    def test_full_https_github_url(self):
+        key, url = _normalise_ref("https://github.com/owner/repo")
+        assert key == "github.com/owner/repo"
+        assert url == "https://github.com/owner/repo.git"
+
+    def test_full_https_with_git_suffix(self):
+        key, url = _normalise_ref("https://github.com/owner/repo.git")
+        assert key == "github.com/owner/repo"
+        assert url == "https://github.com/owner/repo.git"
+
+    def test_gitlab_com_url(self):
+        key, url = _normalise_ref("https://gitlab.com/group/project")
+        assert key == "gitlab.com/group/project"
+        assert url == "https://gitlab.com/group/project.git"
+
+    def test_gitlab_subgroup_url(self):
+        key, url = _normalise_ref("https://gitlab.com/group/subgroup/project")
+        assert key == "gitlab.com/group/subgroup/project"
+
+    def test_self_hosted_gitlab_url(self):
+        key, url = _normalise_ref("https://gitlab.internal/team/proj")
+        assert key == "gitlab.internal/team/proj"
+        assert "gitlab.internal" in url
+
+    def test_short_form_owner_repo(self):
+        key, url = _normalise_ref("owner/repo")
+        assert key == "github.com/owner/repo"
+        assert "github.com" in url
+
+    def test_host_qualified_path(self):
+        key, url = _normalise_ref("github.com/owner/repo")
+        assert key == "github.com/owner/repo"
+
+    def test_empty_ref_raises(self):
+        with pytest.raises(WorkspaceError, match="must not be empty"):
+            _normalise_ref("")
+
+    def test_url_with_too_short_path_raises(self):
+        with pytest.raises(WorkspaceError):
+            _normalise_ref("https://github.com/onlyone")
+
+    def test_host_path_too_short_raises(self):
+        with pytest.raises(WorkspaceError):
+            _normalise_ref("github.com/owner")  # missing repo name
+
+    def test_bare_single_word_raises(self):
+        with pytest.raises(WorkspaceError):
+            _normalise_ref("notarepo")
+
+    def test_git_suffix_stripped_from_key(self):
+        key, _ = _normalise_ref("https://github.com/owner/repo.git")
+        assert not key.endswith(".git")
+
+    def test_trailing_slash_ignored(self):
+        key, _ = _normalise_ref("github.com/owner/repo/")
+        assert key == "github.com/owner/repo"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. WorkspaceManager.resolve — fresh clone
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestWorkspaceManagerFreshClone:
+
+    def test_resolve_calls_git_clone_for_new_repo(self, tmp_path):
+        ws = WorkspaceManager(tmp_path / "ws")
+
+        with patch("infra.workspace._authenticated_clone_url",
+                   return_value="https://token@github.com/owner/repo.git"), \
+             patch("infra.workspace._run_git") as mock_git:
+
+            # Simulate successful clone by creating the target dir
+            def fake_run_git(args, cwd=None, timeout=300):
+                if args[0] == "clone":
+                    Path(args[2]).mkdir(parents=True, exist_ok=True)
+                    (Path(args[2]) / ".git").mkdir()
+                return ""
+            mock_git.side_effect = fake_run_git
+
+            result = ws.resolve("owner/repo")
+
+        assert result == tmp_path / "ws" / "github.com" / "owner" / "repo"
+        # clone was called
+        clone_calls = [c for c in mock_git.call_args_list if c[0][0][0] == "clone"]
+        assert len(clone_calls) == 1
+
+    def test_resolve_path_mirrors_host_owner_repo(self, tmp_path):
+        ws = WorkspaceManager(tmp_path / "ws")
+
+        with patch("infra.workspace._authenticated_clone_url", return_value="url"), \
+             patch("infra.workspace._run_git") as mock_git:
+            def create_dir(args, cwd=None, timeout=300):
+                if args[0] == "clone":
+                    Path(args[2]).mkdir(parents=True)
+                    (Path(args[2]) / ".git").mkdir()
+                return ""
+            mock_git.side_effect = create_dir
+
+            path = ws.resolve("https://gitlab.com/group/proj")
+
+        assert path == tmp_path / "ws" / "gitlab.com" / "group" / "proj"
+
+    def test_resolve_uses_authenticated_url(self, tmp_path):
+        ws = WorkspaceManager(tmp_path / "ws")
+        auth_url = "https://mytoken@github.com/owner/repo.git"
+
+        with patch("infra.workspace._authenticated_clone_url",
+                   return_value=auth_url) as mock_auth, \
+             patch("infra.workspace._run_git") as mock_git:
+            def create_dir(args, cwd=None, timeout=300):
+                if args[0] == "clone":
+                    Path(args[2]).mkdir(parents=True)
+                    (Path(args[2]) / ".git").mkdir()
+                return ""
+            mock_git.side_effect = create_dir
+
+            ws.resolve("owner/repo")
+
+        # The authenticated URL must have been used in the clone call
+        clone_calls = [c for c in mock_git.call_args_list if c[0][0][0] == "clone"]
+        assert clone_calls[0][0][0][1] == auth_url
+
+    def test_resolve_git_clone_failure_raises_workspace_error(self, tmp_path):
+        ws = WorkspaceManager(tmp_path / "ws")
+
+        with patch("infra.workspace._authenticated_clone_url", return_value="url"), \
+             patch("infra.workspace._run_git",
+                   side_effect=WorkspaceError("clone failed: auth error")):
+
+            with pytest.raises(WorkspaceError, match="clone failed"):
+                ws.resolve("owner/repo")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. WorkspaceManager.resolve — existing clone (pull)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestWorkspaceManagerPull:
+
+    def _make_existing_repo(self, base: Path, canonical: str) -> Path:
+        """Create a fake existing local clone."""
+        repo_path = base / Path(*canonical.split("/"))
+        repo_path.mkdir(parents=True)
+        (repo_path / ".git").mkdir()
+        return repo_path
+
+    def test_resolve_existing_repo_does_not_clone(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        self._make_existing_repo(tmp_path, "github.com/owner/repo")
+
+        with patch("infra.workspace._run_git") as mock_git:
+            mock_git.return_value = "origin/main"
+            ws.resolve("owner/repo")
+
+        # fetch should be called, but not clone
+        all_cmds = [c[0][0][0] for c in mock_git.call_args_list]
+        assert "clone" not in all_cmds
+        assert "fetch" in all_cmds
+
+    def test_resolve_existing_calls_fetch_checkout_pull(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        repo_path = self._make_existing_repo(tmp_path, "github.com/owner/repo")
+
+        git_calls = []
+        def record_git(args, cwd=None, timeout=300):
+            git_calls.append(args[0] if args else "")
+            if args[:2] == ["symbolic-ref", "refs/remotes/origin/HEAD"]:
+                return "origin/main"
+            return ""
+        
+        with patch("infra.workspace._run_git", side_effect=record_git):
+            ws.resolve("owner/repo")
+
+        assert "fetch" in git_calls
+        assert "checkout" in git_calls
+        assert "pull" in git_calls
+
+    def test_resolve_existing_uses_detected_default_branch(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        self._make_existing_repo(tmp_path, "github.com/owner/repo")
+
+        checkout_args = []
+        def fake_git(args, cwd=None, timeout=300):
+            if args[0] == "checkout":
+                checkout_args.extend(args)
+            if args[:2] == ["symbolic-ref", "refs/remotes/origin/HEAD"]:
+                return "origin/develop"
+            return ""
+
+        with patch("infra.workspace._run_git", side_effect=fake_git):
+            ws.resolve("owner/repo")
+
+        assert "develop" in checkout_args
+
+    def test_resolve_fetch_failure_continues(self, tmp_path):
+        """Fetch failure should log a warning and return existing state, not raise."""
+        ws = WorkspaceManager(tmp_path)
+        self._make_existing_repo(tmp_path, "github.com/owner/repo")
+
+        def fail_fetch(args, cwd=None, timeout=300):
+            if args[0] == "fetch":
+                raise WorkspaceError("fetch failed: connection refused")
+            return "origin/main"
+
+        with patch("infra.workspace._run_git", side_effect=fail_fetch):
+            path = ws.resolve("owner/repo")  # must not raise
+
+        assert path.exists()
+
+    def test_resolve_returns_correct_path_for_existing(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        expected = self._make_existing_repo(tmp_path, "github.com/owner/repo")
+
+        with patch("infra.workspace._run_git", return_value="origin/main"):
+            result = ws.resolve("owner/repo")
+
+        assert result == expected
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. WorkspaceManager.clean
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestWorkspaceManagerClean:
+
+    def test_clean_removes_directory(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        repo_path = tmp_path / "github.com" / "owner" / "repo"
+        repo_path.mkdir(parents=True)
+        (repo_path / "file.txt").write_text("content")
+
+        ws.clean("owner/repo")
+
+        assert not repo_path.exists()
+
+    def test_clean_nonexistent_is_noop(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        ws.clean("owner/nonexistent")  # must not raise
+
+    def test_clean_removes_empty_parent_dirs(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        repo_path = tmp_path / "github.com" / "singleowner" / "only-repo"
+        repo_path.mkdir(parents=True)
+
+        ws.clean("github.com/singleowner/only-repo")
+
+        # repo dir gone
+        assert not repo_path.exists()
+        # owner dir should be gone too (was empty)
+        assert not (tmp_path / "github.com" / "singleowner").exists()
+
+    def test_clean_invalid_ref_logs_warning_no_raise(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        ws.clean("not-a-valid/ref/with/too/many/levels/and/extra")  # must not raise
+
+    def test_clean_leaves_sibling_repos(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        repo_a = tmp_path / "github.com" / "owner" / "repo-a"
+        repo_b = tmp_path / "github.com" / "owner" / "repo-b"
+        repo_a.mkdir(parents=True)
+        repo_b.mkdir(parents=True)
+
+        ws.clean("github.com/owner/repo-a")
+
+        assert not repo_a.exists()
+        assert repo_b.exists()  # sibling untouched
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. WorkspaceManager.list_workspaces
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestWorkspaceManagerList:
+
+    def test_list_empty_workspace(self, tmp_path):
+        ws = WorkspaceManager(tmp_path / "ws")
+        assert ws.list_workspaces() == []
+
+    def test_list_nonexistent_root(self, tmp_path):
+        ws = WorkspaceManager(tmp_path / "nonexistent")
+        assert ws.list_workspaces() == []
+
+    def test_list_detects_git_dirs(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        for path in ("github.com/owner/repo-a", "github.com/owner/repo-b"):
+            repo = tmp_path / Path(*path.split("/"))
+            repo.mkdir(parents=True)
+            (repo / ".git").mkdir()
+
+        infos = ws.list_workspaces()
+        refs = {i.repo_ref for i in infos}
+        assert "github.com/owner/repo-a" in refs
+        assert "github.com/owner/repo-b" in refs
+
+    def test_list_ignores_non_git_dirs(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        not_a_repo = tmp_path / "github.com" / "owner" / "not-cloned"
+        not_a_repo.mkdir(parents=True)
+        (not_a_repo / "some_file.txt").write_text("nope")
+
+        assert ws.list_workspaces() == []
+
+    def test_list_returns_workspace_info_objects(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        repo = tmp_path / "github.com" / "owner" / "repo"
+        repo.mkdir(parents=True)
+        (repo / ".git").mkdir()
+
+        infos = ws.list_workspaces()
+        assert len(infos) == 1
+        info = infos[0]
+        assert isinstance(info, WorkspaceInfo)
+        assert info.local_path == repo
+        assert info.last_used is not None
+
+    def test_list_mixed_hosts(self, tmp_path):
+        ws = WorkspaceManager(tmp_path)
+        for path in ("github.com/a/b", "gitlab.com/c/d", "internal.corp/team/proj"):
+            repo = tmp_path / Path(*path.split("/"))
+            repo.mkdir(parents=True)
+            (repo / ".git").mkdir()
+
+        infos = ws.list_workspaces()
+        assert len(infos) == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. active_repo context variable
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestActiveRepoContextVar:
+
+    def test_default_falls_back_to_settings(self):
+        clear_repo_root()
+        with patch("app.core.config.get_settings",
+                   return_value=SimpleNamespace(target_repo_path="/static/path")):
+            result = get_repo_root()
+        assert result == "/static/path"
+
+    def test_set_overrides_settings(self):
+        set_repo_root("/dynamic/path")
+        # Context var wins — settings irrelevant
+        result = get_repo_root()
+        assert result == "/dynamic/path"
+
+    def test_clear_restores_settings_fallback(self):
+        set_repo_root("/dynamic/path")
+        clear_repo_root()
+        with patch("app.core.config.get_settings",
+                   return_value=SimpleNamespace(target_repo_path="/static/path")):
+            result = get_repo_root()
+        assert result == "/static/path"
+
+    def test_settings_exception_returns_empty(self):
+        clear_repo_root()
+        with patch("app.core.config.get_settings",
+                   side_effect=Exception("no settings")):
+            result = get_repo_root()
+        assert result == ""
+
+    def test_set_empty_string_reverts_to_fallback(self):
+        set_repo_root("/dynamic")
+        set_repo_root("")   # clear
+        with patch("app.core.config.get_settings",
+                   return_value=SimpleNamespace(target_repo_path="/static")):
+            assert get_repo_root() == "/static"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. Tools use get_repo_root
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestToolsUseDynamicRoot:
+
+    def test_filesystem_uses_context_var(self, tmp_path):
+        """filesystem._resolve_safe must use get_repo_root(), not settings directly."""
+        from app.tools.filesystem import _resolve_safe
+
+        set_repo_root(str(tmp_path))
+        resolved = _resolve_safe("subdir/file.txt")
+        assert str(resolved).startswith(str(tmp_path))
+
+    def test_filesystem_rejects_escape_even_with_context_var(self, tmp_path):
+        from app.tools.filesystem import PathEscapeError, _resolve_safe
+
+        set_repo_root(str(tmp_path))
+        with pytest.raises((PathEscapeError, FileNotFoundError)):
+            _resolve_safe("../../etc/passwd")
+
+    def test_git_tool_uses_context_var(self, tmp_path):
+        """git._run_git must read repo root from get_repo_root()."""
+        from app.tools import git as git_mod
+
+        set_repo_root(str(tmp_path))
+        with patch("app.core.active_repo.get_repo_root", return_value=str(tmp_path)):
+            root = Path(get_repo_root()).resolve()
+        assert root == tmp_path.resolve()
+
+    def test_build_run_tests_uses_context_var(self, tmp_path):
+        """build.run_tests must call get_repo_root(), not settings.target_repo_path."""
+        from app.tools import build as build_mod
+
+        set_repo_root(str(tmp_path))
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+        with patch("app.tools.build.run_terminal") as mock_term:
+            mock_term.invoke = MagicMock(return_value="1 passed")
+            # Just verify the function doesn't error and calls terminal
+            from app.tools.build import run_tests
+            # The tool reads get_repo_root() for project detection
+            with patch("app.core.active_repo.get_repo_root", return_value=str(tmp_path)):
+                from app.tools.build import _detect_project_type
+                types = _detect_project_type(str(tmp_path))
+            assert "python" in types
+
+    def test_shell_uses_context_var(self, tmp_path):
+        """shell.run_shell must use get_repo_root() for the sandbox root."""
+        import app.tools.shell as shell_mod
+
+        set_repo_root(str(tmp_path))
+        with patch("app.core.active_repo.get_repo_root", return_value=str(tmp_path)):
+            root = Path(get_repo_root()).resolve()
+        assert root == tmp_path.resolve()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. Config keys
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestConfigKeys:
+
+    def test_daedalus_workspace_dir_exists(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert hasattr(s, "daedalus_workspace_dir")
+
+    def test_daedalus_workspace_dir_default_is_resolved(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        # Default should be expanded/resolved (no tilde)
+        assert "~" not in s.daedalus_workspace_dir
+        assert Path(s.daedalus_workspace_dir).is_absolute()
+
+    def test_target_repo_path_still_works(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        # target_repo_path must still exist (backward compat)
+        assert hasattr(s, "target_repo_path")
+
+    def test_daedalus_workspace_dir_default_contains_daedalus(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert "daedalus" in s.daedalus_workspace_dir.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 9. GraphState.repo_ref
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestStateRepoRef:
+
+    def test_repo_ref_field_exists(self):
+        from app.core.state import GraphState
+        s = GraphState(user_request="test")
+        assert hasattr(s, "repo_ref")
+
+    def test_repo_ref_default_empty_string(self):
+        from app.core.state import GraphState
+        s = GraphState(user_request="test")
+        assert s.repo_ref == ""
+
+    def test_repo_ref_round_trips_through_model_dump(self):
+        from app.core.state import GraphState
+        s = GraphState(user_request="test", repo_ref="owner/repo")
+        d = s.model_dump()
+        assert d["repo_ref"] == "owner/repo"
+        s2 = GraphState(**d)
+        assert s2.repo_ref == "owner/repo"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 10. context_loader_node — workspace integration
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestContextLoaderWorkspaceIntegration:
+
+    def _make_settings(self, tmp_path, target_repo_path=""):
+        return SimpleNamespace(
+            target_repo_path=target_repo_path,
+            daedalus_workspace_dir=str(tmp_path / "ws"),
+            max_output_chars=10000,
+            context_warn_fraction=0.7,
+            tool_result_max_chars=8000,
+        )
+
+    def test_static_path_bypasses_workspace(self, tmp_path, monkeypatch):
+        """When repo_root or target_repo_path is set, no WorkspaceManager call."""
+        from app.core import nodes
+
+        (tmp_path / "README.md").write_text("hello")
+
+        mock_ws = MagicMock()
+        monkeypatch.setattr(nodes, "get_settings",
+                            lambda: self._make_settings(tmp_path, str(tmp_path)))
+
+        with patch("infra.workspace.WorkspaceManager") as MockWS:
+            state = __import__("app.core.state", fromlist=["GraphState"]).GraphState(
+                user_request="test", repo_root=str(tmp_path)
+            )
+            result = nodes.context_loader_node(state)
+
+        MockWS.assert_not_called()
+        assert result.get("context_loaded") is True
+
+    def test_missing_repo_root_and_ref_stops(self, tmp_path, monkeypatch):
+        """With neither repo_root nor repo_ref, workflow must stop."""
+        from app.core import nodes
+        from app.core.state import GraphState
+
+        monkeypatch.setattr(nodes, "get_settings",
+                            lambda: self._make_settings(tmp_path, target_repo_path=""))
+
+        state = GraphState(user_request="test", repo_root="", repo_ref="")
+        result = nodes.context_loader_node(state)
+
+        assert result["context_loaded"] is False
+        assert "missing" in result["stop_reason"].lower()
+
+    def test_workspace_resolve_called_when_no_static_path(self, tmp_path, monkeypatch):
+        """When repo_root is empty but repo_ref is set, WorkspaceManager.resolve is called."""
+        from app.core import nodes
+        from app.core.state import GraphState
+
+        monkeypatch.setattr(nodes, "get_settings",
+                            lambda: self._make_settings(tmp_path, target_repo_path=""))
+
+        # Make a fake resolved path
+        fake_repo = tmp_path / "github.com" / "owner" / "repo"
+        fake_repo.mkdir(parents=True)
+        (fake_repo / "README.md").write_text("# Fake repo")
+
+        mock_ws_instance = MagicMock()
+        mock_ws_instance.resolve.return_value = fake_repo
+
+        with patch("infra.workspace.WorkspaceManager", return_value=mock_ws_instance):
+            state = GraphState(user_request="test", repo_root="", repo_ref="owner/repo")
+            result = nodes.context_loader_node(state)
+
+        mock_ws_instance.resolve.assert_called_once_with("owner/repo")
+        assert result.get("context_loaded") is True
+
+    def test_workspace_error_stops_workflow(self, tmp_path, monkeypatch):
+        """WorkspaceManager.resolve raising WorkspaceError must stop the workflow."""
+        from app.core import nodes
+        from app.core.state import GraphState
+        from infra.workspace import WorkspaceError
+
+        monkeypatch.setattr(nodes, "get_settings",
+                            lambda: self._make_settings(tmp_path, target_repo_path=""))
+
+        mock_ws_instance = MagicMock()
+        mock_ws_instance.resolve.side_effect = WorkspaceError("auth failed")
+
+        with patch("infra.workspace.WorkspaceManager", return_value=mock_ws_instance):
+            state = GraphState(user_request="test", repo_root="", repo_ref="owner/repo")
+            result = nodes.context_loader_node(state)
+
+        assert result["context_loaded"] is False
+        assert "workspace" in result["stop_reason"].lower()
+
+    def test_resolved_repo_root_in_return_dict(self, tmp_path, monkeypatch):
+        """context_loader must return the resolved repo_root so state is persisted."""
+        from app.core import nodes
+        from app.core.state import GraphState
+
+        monkeypatch.setattr(nodes, "get_settings",
+                            lambda: self._make_settings(tmp_path, target_repo_path=""))
+
+        fake_repo = tmp_path / "github.com" / "owner" / "repo"
+        fake_repo.mkdir(parents=True)
+        (fake_repo / "README.md").write_text("# x")
+
+        mock_ws_instance = MagicMock()
+        mock_ws_instance.resolve.return_value = fake_repo
+
+        with patch("infra.workspace.WorkspaceManager", return_value=mock_ws_instance):
+            state = GraphState(user_request="test", repo_root="", repo_ref="owner/repo")
+            result = nodes.context_loader_node(state)
+
+        assert "repo_root" in result
+        assert result["repo_root"] == str(fake_repo.resolve())
+
+    def test_context_var_set_after_resolve(self, tmp_path, monkeypatch):
+        """set_repo_root must be called with the resolved path so tools use it."""
+        from app.core import nodes
+        from app.core.state import GraphState
+        import app.core.active_repo as ar
+
+        monkeypatch.setattr(nodes, "get_settings",
+                            lambda: self._make_settings(tmp_path, target_repo_path=""))
+
+        fake_repo = tmp_path / "github.com" / "owner" / "repo"
+        fake_repo.mkdir(parents=True)
+        (fake_repo / "README.md").write_text("# x")
+
+        mock_ws_instance = MagicMock()
+        mock_ws_instance.resolve.return_value = fake_repo
+
+        set_root_calls = []
+        original_set = ar.set_repo_root
+        def track_set(path):
+            set_root_calls.append(path)
+            original_set(path)
+
+        with patch("infra.workspace.WorkspaceManager", return_value=mock_ws_instance), \
+             patch("app.core.active_repo.set_repo_root", side_effect=track_set):
+            state = GraphState(user_request="test", repo_root="", repo_ref="owner/repo")
+            nodes.context_loader_node(state)
+
+        assert any(str(fake_repo.resolve()) in p for p in set_root_calls)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 11. infra package exports WorkspaceManager
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestInfraExports:
+
+    def test_workspace_manager_exported(self):
+        import infra
+        assert hasattr(infra, "WorkspaceManager")
+
+    def test_workspace_info_exported(self):
+        import infra
+        assert hasattr(infra, "WorkspaceInfo")
+
+    def test_workspace_error_exported(self):
+        import infra
+        assert hasattr(infra, "WorkspaceError")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 12. run_workflow forwards repo_ref
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRunWorkflowRepoRef:
+
+    @pytest.mark.asyncio
+    async def test_repo_ref_propagated_to_initial_state(self):
+        """run_workflow must put repo_ref into the initial GraphState."""
+        from app.core.orchestrator import run_workflow
+        from app.core.state import GraphState, WorkflowPhase
+
+        captured_states = []
+
+        async def fake_to_thread(fn, state_dict):
+            captured_states.append(state_dict)
+            # Return a minimal valid completed state
+            s = GraphState(
+                user_request="test",
+                repo_root="/tmp/fake",
+                repo_ref="owner/repo",
+                phase=WorkflowPhase.COMPLETE,
+            )
+            return s.model_dump()
+
+        with patch("asyncio.to_thread", side_effect=fake_to_thread), \
+             patch("app.core.orchestrator.compile_graph"):
+            await run_workflow("test task", "/tmp/fake", repo_ref="owner/repo")
+
+        assert len(captured_states) == 1
+        assert captured_states[0].get("repo_ref") == "owner/repo"
+
+    @pytest.mark.asyncio
+    async def test_empty_repo_ref_defaults_to_empty_string(self):
+        from app.core.orchestrator import run_workflow
+        from app.core.state import GraphState, WorkflowPhase
+
+        captured = []
+
+        async def fake_to_thread(fn, state_dict):
+            captured.append(state_dict)
+            s = GraphState(user_request="t", phase=WorkflowPhase.COMPLETE)
+            return s.model_dump()
+
+        with patch("asyncio.to_thread", side_effect=fake_to_thread), \
+             patch("app.core.orchestrator.compile_graph"):
+            await run_workflow("test", "/tmp/fake")
+
+        assert captured[0].get("repo_ref", "") == ""


### PR DESCRIPTION
Implements Issue #45: WorkspaceManager clones or pulls repos on-demand when TARGET_REPO_PATH is not set. TARGET_REPO_PATH continues to work as a static override for backward compatibility.

## New files

### app/core/active_repo.py
Per-task repository root context variable (ContextVar).
- set_repo_root(path) / get_repo_root() / clear_repo_root()
- Resolution order: ContextVar → settings.target_repo_path → ''
- Async-safe: each LangGraph task gets its own context without mutating the global Settings singleton. Enables future parallel task execution.

### infra/workspace.py — WorkspaceManager
- resolve(repo_ref) → Path: clone fresh or fetch+checkout+pull existing
- clean(repo_ref): remove local clone + empty parent dirs
- list_workspaces(): scan workspace root for .git dirs → WorkspaceInfo
- _normalise_ref: parses full URLs, host/owner/repo, owner/repo (GitHub shorthand); strips .git suffix; raises WorkspaceError on bad input
- Clone uses authenticated URL from ForgeClient.clone_url()
- Pull: git fetch origin → detect default branch → checkout → pull --ff-only
- Fetch failure is non-fatal (logs warning, continues with local state)
- WorkspaceError raised for clone failures and unparseable refs
- Workspace layout: workspace_root/github.com/owner/repo gitlab.com/group/project gitlab.internal/team/repo

## Changed files

### app/core/config.py
- daedalus_workspace_dir: str = '~/daedalus-workspace' (new key) Resolved by @field_validator (expanduser + resolve, no ~)
- target_repo_path comment clarified as 'static override'

### app/core/state.py
- repo_ref: str = '' added alongside repo_root Stores the forge reference (URL / owner/name) for WorkspaceManager

### app/tools/filesystem.py + git.py + shell.py + build.py
- All four tools replaced settings.target_repo_path with get_repo_root()
- Sandbox root is now per-task-dynamic, not process-global

### app/core/memory.py
- _repo_root() now calls get_repo_root() instead of settings directly

### app/core/nodes.py (context_loader_node)
- When repo_root is empty: read state.repo_ref, call WorkspaceManager.resolve()
- Emits status events during clone/pull
- WorkspaceError → STOPPED with stop_reason='context_workspace_error'
- Calls set_repo_root(resolved_path) so all tools use it from this point
- Returns repo_root in dict so resolved path is persisted in GraphState

### app/core/orchestrator.py (run_workflow)
- New repo_ref parameter forwarded to initial GraphState
- Calls set_repo_root for static path if known at workflow start

### app/web/server.py
- TaskRequest gains repo_ref: str = '' field
- _process_tasks passes repo_ref to run_workflow
- WS message → TaskRequest conversion includes repo_ref

### app/telegram/bot.py
- Passes repo_ref='' explicitly; backward-compatible

## Updated tests

### tests/test_workspace.py (new, 61 tests)
_normalise_ref (13), WorkspaceManager fresh clone (4), existing pull (5), clean (5), list_workspaces (6), active_repo context var (5), tools use dynamic root (5), config keys (4), GraphState.repo_ref (3), context_loader integration (6), infra exports (3), run_workflow (2)

### tests/test_filesystem.py + test_git.py + test_memory.py + test_shell.py Fixtures updated: set_repo_root(tmp_path) + clear_repo_root() added alongside existing get_settings patches so tools find the correct sandbox root through the new context variable.

Full test suite: 857 passed / 0 failed

Closes #45