### PR TITLE
feat: repo registry — YAML-based access control (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to the Daedalus project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [2.2.0] - 2026-02-25
+
+### Added — Repo Registry (YAML-based access control)
+
+- **`repos.yaml`** — new registry file at project root; defines every
+  repository Daedalus is permitted to clone or modify.
+- **`infra/registry.py`** — `RepoEntry` Pydantic model and `RepoRegistry`
+  class with `load()`, `resolve()`, `is_allowed()`, `list_repos()`.
+- **`get_registry()`** singleton factory; auto-loads `repos.yaml` and
+  respects `REPOS_YAML_PATH` config / env var.
+- **Registry guard in `context_loader_node`** — tasks targeting unknown
+  repos are stopped with `stop_reason="context_repo_not_in_registry"`.
+  Guard is skipped when the registry is empty (permissive default).
+- **`_extract_repo_ref()`** helper in `nodes.py` — detects repo references
+  from free-form user text: full HTTPS URL, no-scheme forge URL,
+  `owner/name` shorthand, or keyword-anchored alias.
+- **Router populates `GraphState.repo_ref`** — extracted from the user
+  request at intent-classification time; passed to context loader.
+- **`/api/status` now includes `registered_repos`** list from the registry.
+- **Telegram `/status` lists registered repos** with names and URLs.
+- **`REPOS_YAML_PATH` config key** added to `app/core/config.py`.
+- **`infra/__init__.py`** exports `RepoEntry`, `RepoRegistry`, `get_registry`.
+- **53 new tests** in `tests/test_registry.py` covering all registry
+  operations, the context_loader guard, and `_extract_repo_ref`.
+
+### Closes
+GitHub issue #46
+
 ## [2.1.0] - 2026-02-22
 
 ### Changed — Provider-agnostic Coder configuration

--- a/README.md
+++ b/README.md
@@ -558,7 +558,12 @@ See `.env.example` for all available settings. Key options:
 | `OPENAI_API_KEY` | — | OpenAI API key (required if any model uses OpenAI) |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (required if any model uses Anthropic) |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL (required if any model uses Ollama) |
-| `TARGET_REPO_PATH` | (required) | Path to target Git repo |
+| `TARGET_REPO_PATH` | (optional) | Static path to target Git repo — overrides WorkspaceManager |
+| `DAEDALUS_WORKSPACE_DIR` | `~/daedalus-workspace` | Directory where repos are cloned on-demand |
+| `REPOS_YAML_PATH` | `repos.yaml` | Path to repo registry file (see [Repo Registry](#-repo-registry)) |
+| `GITLAB_URL` | `https://gitlab.com` | Base URL of your GitLab instance |
+| `GITLAB_TOKEN` | — | GitLab personal access token |
+| `GITHUB_TOKEN` | — | GitHub personal access token |
 | `CODER_1_MODEL` | `gpt-4o-mini` | Model for Coder 1 — prefix `ollama:` for local models |
 | `CODER_2_MODEL` | `gpt-4o-mini` | Model for Coder 2 — prefix `ollama:` for local models |
 | `PLANNER_MODEL` | `gpt-4o-mini` | Model for Planner |
@@ -571,6 +576,52 @@ See `.env.example` for all available settings. Key options:
 | `MAX_ITERATIONS_PER_ITEM` | `5` | Max rework attempts per item |
 | `SHELL_TIMEOUT_SECONDS` | `120` | Shell command timeout |
 | `LOG_LEVEL` | `INFO` | Logging level |
+
+## 📋 Repo Registry
+
+Daedalus uses `repos.yaml` (project root) as an access control list.
+Only repositories listed there may be cloned or modified.  Any task
+targeting an unknown repo is rejected before the workflow starts.
+
+### repos.yaml schema
+
+```yaml
+# repos.yaml — repositories Daedalus is permitted to work on
+repos:
+  - name: my-api                          # short alias for Telegram / Web UI
+    url: https://github.com/org/my-api    # full HTTPS forge URL (platform auto-detected)
+    default_branch: main                  # branch to check out and target for PRs
+    description: "Main backend API"       # shown in /status
+
+  - name: infra-scripts
+    url: https://gitlab.internal/ops/infra-scripts
+    default_branch: main
+    description: "Internal infrastructure scripts"
+```
+
+### Referencing repos in tasks
+
+You can reference a repo in any task by:
+
+| Format | Example |
+|--------|---------|
+| Name alias | `fix issue #42 in my-api` |
+| Full URL | `add feature to https://github.com/org/my-api` |
+| `owner/name` | `refactor org/my-api` |
+| No-scheme URL | `analyse github.com/org/my-api` |
+
+### Permissive default
+
+If `repos.yaml` exists but is **empty** (`repos: []`), the registry guard
+is skipped and any repo ref is accepted.  Populate the file to enforce
+access control.
+
+### Custom path
+
+Set `REPOS_YAML_PATH=/path/to/custom-repos.yaml` to use a file outside
+the project root.
+
+---
 
 ## 🆕 What Changed in v2.0
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -61,6 +61,11 @@ class Settings(BaseSettings):
     # Target repo — static override; takes precedence over WorkspaceManager
     target_repo_path: str = ""
 
+    # Repo registry — path to repos.yaml.
+    # Relative paths are resolved from CWD at runtime.
+    # Leave empty to use the default repos.yaml in the project root.
+    repos_yaml_path: str = ""
+
     @field_validator("target_repo_path")
     @classmethod
     def _resolve_repo(cls, value: str) -> str:

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -22,6 +22,7 @@ from infra.forge import ForgeClient, ForgeError, Issue, PRRequest, PRResult
 from infra.github_client import GitHubClient
 from infra.gitlab_client import GitLabClient
 from infra.workspace import WorkspaceError, WorkspaceInfo, WorkspaceManager
+from infra.registry import RepoEntry, RepoRegistry, get_registry
 
 __all__ = [
     # Protocol & models
@@ -41,4 +42,8 @@ __all__ = [
     "WorkspaceManager",
     "WorkspaceInfo",
     "WorkspaceError",
+    # Registry
+    "RepoEntry",
+    "RepoRegistry",
+    "get_registry",
 ]

--- a/infra/registry.py
+++ b/infra/registry.py
@@ -1,0 +1,285 @@
+"""Repo registry — YAML-based access control for Daedalus.
+
+Only repositories listed in ``repos.yaml`` (project root) may be cloned or
+modified by Daedalus.  Any task targeting an unknown repo is rejected before
+the workflow starts.
+
+Schema example (``repos.yaml``)::
+
+    repos:
+      - name: my-api
+        url: https://github.com/org/my-api
+        default_branch: main
+        description: "Main backend API"
+
+      - name: infra-scripts
+        url: https://gitlab.internal/ops/infra-scripts
+        default_branch: main
+        description: "Internal infrastructure scripts"
+
+Typical usage::
+
+    from infra.registry import get_registry
+
+    registry = get_registry()          # loads repos.yaml on first call
+    entry    = registry.resolve("my-api")
+    if not registry.is_allowed("https://github.com/org/my-api"):
+        raise ValueError("Repo not in registry")
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterator
+from urllib.parse import urlparse
+
+import yaml
+from pydantic import BaseModel, field_validator
+
+from app.core.logging import get_logger
+
+logger = get_logger("infra.registry")
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+_DEFAULT_REPOS_YAML = Path(__file__).parent.parent / "repos.yaml"
+
+
+class RepoEntry(BaseModel):
+    """A single repository entry in the registry."""
+
+    name: str
+    """Short alias used in Telegram tasks and the Web UI (e.g. ``my-api``)."""
+
+    url: str
+    """Full forge URL (e.g. ``https://github.com/org/my-api``)."""
+
+    default_branch: str = "main"
+    """Branch that Daedalus checks out and targets for PRs/MRs."""
+
+    description: str = ""
+    """Human-readable description shown in ``/status`` and the Web UI."""
+
+    @field_validator("name")
+    @classmethod
+    def _name_no_spaces(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("name must not be empty")
+        return v.strip()
+
+    @field_validator("url")
+    @classmethod
+    def _url_non_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("url must not be empty")
+        return v.strip().rstrip("/")
+
+    # ── Derived helpers ──────────────────────────────────────────────────
+
+    @property
+    def owner_name(self) -> str:
+        """``owner/name`` shorthand extracted from the URL, e.g. ``org/my-api``."""
+        parsed = urlparse(self.url)
+        parts = parsed.path.strip("/").split("/")
+        if len(parts) >= 2:
+            return "/".join(parts[-2:])
+        return ""
+
+    @property
+    def canonical_key(self) -> str:
+        """``host/owner/name`` key, e.g. ``github.com/org/my-api``."""
+        parsed = urlparse(self.url)
+        return f"{parsed.netloc}/{parsed.path.strip('/')}"
+
+    def matches(self, ref: str) -> bool:
+        """Return True if *ref* refers to this entry.
+
+        Accepted forms:
+        - Name alias      → ``"my-api"``
+        - Full URL        → ``"https://github.com/org/my-api"``
+        - No-scheme URL   → ``"github.com/org/my-api"``
+        - owner/name      → ``"org/my-api"``
+        """
+        ref = ref.strip().rstrip("/")
+        if not ref:
+            return False
+
+        normalised = ref.lower()
+
+        # 1. Name alias (case-insensitive)
+        if normalised == self.name.lower():
+            return True
+
+        # 2. Full URL (normalise scheme differences)
+        url_no_scheme = re.sub(r"^https?://", "", self.url.lower())
+        ref_no_scheme = re.sub(r"^https?://", "", normalised)
+        if ref_no_scheme == url_no_scheme:
+            return True
+
+        # 3. owner/name shorthand
+        if self.owner_name and normalised == self.owner_name.lower():
+            return True
+
+        # 4. host/owner/name canonical key
+        if normalised == self.canonical_key.lower():
+            return True
+
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class RepoRegistry:
+    """In-memory registry loaded from ``repos.yaml``.
+
+    Thread-safe for reads after :meth:`load` completes.
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[RepoEntry] = []
+        self._loaded_path: Path | None = None
+
+    # ── Loading ──────────────────────────────────────────────────────────
+
+    def load(self, path: Path | None = None) -> None:
+        """Load (or reload) the registry from a YAML file.
+
+        Args:
+            path: Path to the YAML file.  Defaults to ``repos.yaml`` in the
+                  project root next to this package.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the YAML is malformed or contains invalid entries.
+        """
+        resolved = Path(path) if path else _DEFAULT_REPOS_YAML
+        if not resolved.exists():
+            logger.warning("repos.yaml not found at %s — registry is empty", resolved)
+            self._entries = []
+            self._loaded_path = resolved
+            return
+
+        raw = yaml.safe_load(resolved.read_text(encoding="utf-8")) or {}
+        raw_repos = raw.get("repos", [])
+        if not isinstance(raw_repos, list):
+            raise ValueError(f"repos.yaml: 'repos' must be a list, got {type(raw_repos)}")
+
+        entries: list[RepoEntry] = []
+        for i, item in enumerate(raw_repos):
+            if not isinstance(item, dict):
+                raise ValueError(f"repos.yaml: entry {i} must be a mapping, got {type(item)}")
+            try:
+                entries.append(RepoEntry(**item))
+            except Exception as exc:
+                raise ValueError(f"repos.yaml: invalid entry {i} ({item!r}): {exc}") from exc
+
+        self._entries = entries
+        self._loaded_path = resolved
+        logger.info(
+            "Registry loaded %d repo(s) from %s",
+            len(self._entries),
+            resolved,
+        )
+
+    def _ensure_loaded(self) -> None:
+        """Auto-load from the default path if not yet loaded."""
+        if self._loaded_path is None:
+            self.load()
+
+    # ── Queries ──────────────────────────────────────────────────────────
+
+    def resolve(self, ref: str) -> RepoEntry:
+        """Return the :class:`RepoEntry` that matches *ref*.
+
+        Matching is tried in this order: name alias → full URL →
+        no-scheme URL → ``owner/name`` shorthand → canonical key.
+
+        Args:
+            ref: Any of the accepted reference forms.
+
+        Returns:
+            The matching :class:`RepoEntry`.
+
+        Raises:
+            ValueError: If no entry matches *ref*.
+        """
+        self._ensure_loaded()
+        for entry in self._entries:
+            if entry.matches(ref):
+                return entry
+        raise ValueError(
+            f"Repository {ref!r} is not in the registry.  "
+            f"Known repos: {[e.name for e in self._entries]}"
+        )
+
+    def is_allowed(self, ref: str) -> bool:
+        """Return True if *ref* matches any registered repository.
+
+        Args:
+            ref: Name alias, URL, or ``owner/name`` shorthand.
+        """
+        self._ensure_loaded()
+        return any(entry.matches(ref) for entry in self._entries)
+
+    def list_repos(self) -> list[RepoEntry]:
+        """Return all registered repositories (read-only copy)."""
+        self._ensure_loaded()
+        return list(self._entries)
+
+    def __iter__(self) -> Iterator[RepoEntry]:
+        self._ensure_loaded()
+        return iter(self._entries)
+
+    def __len__(self) -> int:
+        self._ensure_loaded()
+        return len(self._entries)
+
+    def __bool__(self) -> bool:
+        return True  # always truthy even when empty
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+_registry: RepoRegistry | None = None
+
+
+def get_registry(path: Path | None = None, *, reload: bool = False) -> RepoRegistry:
+    """Return the singleton :class:`RepoRegistry`, loading it on first call.
+
+    Resolution order for the YAML file:
+    1. ``path`` argument (tests / explicit override)
+    2. ``REPOS_YAML_PATH`` env / config setting
+    3. ``repos.yaml`` next to the project root (default)
+
+    Args:
+        path:   Override the default ``repos.yaml`` path (mainly for tests).
+        reload: Force a reload even if already loaded.
+    """
+    global _registry
+    if _registry is None or reload or path is not None:
+        resolved_path = path
+        if resolved_path is None:
+            # Respect config setting if provided
+            try:
+                from app.core.config import get_settings
+                cfg_path = get_settings().repos_yaml_path
+                if cfg_path:
+                    resolved_path = Path(cfg_path).expanduser().resolve()
+            except Exception:
+                pass
+
+        r = RepoRegistry()
+        r.load(resolved_path)
+        if path is None and not reload:
+            _registry = r
+        else:
+            return r
+    return _registry

--- a/repos.yaml
+++ b/repos.yaml
@@ -1,0 +1,29 @@
+# repos.yaml — repositories Daedalus is permitted to clone and modify
+#
+# Add every repo you want Daedalus to be able to work on here.
+# Daedalus will refuse any task that targets a repo not listed in this file.
+#
+# Fields:
+#   name           Short alias used in Telegram tasks and the Web UI.
+#                  Example: "fix issue #42 in my-api"  (required, unique)
+#   url            Full HTTPS forge URL.                                  (required)
+#   default_branch Branch Daedalus checks out and targets for PRs/MRs.   (default: main)
+#   description    Human-readable description shown in /status.           (optional)
+#
+# Platform is auto-detected from the URL:
+#   - github.com           → GitHub
+#   - configured GITLAB_URL → GitLab (set GITLAB_URL env var for self-hosted)
+#
+# Examples:
+repos:
+  # ── GitHub example ────────────────────────────────────────────────────────
+  # - name: my-api
+  #   url: https://github.com/org/my-api
+  #   default_branch: main
+  #   description: "Main backend API"
+
+  # ── Self-hosted GitLab example ────────────────────────────────────────────
+  # - name: infra-scripts
+  #   url: https://gitlab.internal/ops/infra-scripts
+  #   default_branch: main
+  #   description: "Internal infrastructure scripts"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,435 @@
+"""Tests for infra.registry — YAML-based repo access control."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from infra.registry import RepoEntry, RepoRegistry, get_registry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "repos.yaml"
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+VALID_YAML = """
+repos:
+  - name: my-api
+    url: https://github.com/org/my-api
+    default_branch: main
+    description: "Main backend API"
+  - name: infra-scripts
+    url: https://gitlab.internal/ops/infra-scripts
+    default_branch: develop
+    description: "Internal infrastructure scripts"
+  - name: no-desc
+    url: https://github.com/org/no-desc
+"""
+
+
+# ---------------------------------------------------------------------------
+# RepoEntry — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRepoEntry:
+    def test_basic_fields(self):
+        e = RepoEntry(name="my-api", url="https://github.com/org/my-api")
+        assert e.name == "my-api"
+        assert e.url == "https://github.com/org/my-api"
+        assert e.default_branch == "main"
+        assert e.description == ""
+
+    def test_trailing_slash_stripped_from_url(self):
+        e = RepoEntry(name="x", url="https://github.com/org/repo/")
+        assert not e.url.endswith("/")
+
+    def test_owner_name(self):
+        e = RepoEntry(name="x", url="https://github.com/acme/myrepo")
+        assert e.owner_name == "acme/myrepo"
+
+    def test_canonical_key(self):
+        e = RepoEntry(name="x", url="https://github.com/acme/myrepo")
+        assert e.canonical_key == "github.com/acme/myrepo"
+
+    def test_canonical_key_gitlab_self_hosted(self):
+        e = RepoEntry(name="x", url="https://gitlab.internal/team/proj")
+        assert e.canonical_key == "gitlab.internal/team/proj"
+
+    def test_matches_name_alias(self):
+        e = RepoEntry(name="my-api", url="https://github.com/org/my-api")
+        assert e.matches("my-api")
+        assert e.matches("MY-API")  # case-insensitive
+
+    def test_matches_full_url(self):
+        e = RepoEntry(name="x", url="https://github.com/org/repo")
+        assert e.matches("https://github.com/org/repo")
+        assert e.matches("https://github.com/org/repo/")  # trailing slash
+
+    def test_matches_no_scheme_url(self):
+        e = RepoEntry(name="x", url="https://github.com/org/repo")
+        assert e.matches("github.com/org/repo")
+
+    def test_matches_owner_name(self):
+        e = RepoEntry(name="x", url="https://github.com/org/repo")
+        assert e.matches("org/repo")
+
+    def test_matches_canonical_key(self):
+        e = RepoEntry(name="x", url="https://github.com/org/repo")
+        assert e.matches("github.com/org/repo")
+
+    def test_does_not_match_unrelated(self):
+        e = RepoEntry(name="my-api", url="https://github.com/org/my-api")
+        assert not e.matches("other-api")
+        assert not e.matches("https://github.com/org/other")
+        assert not e.matches("")
+        assert not e.matches("   ")
+
+    def test_name_empty_raises(self):
+        with pytest.raises(Exception):
+            RepoEntry(name="   ", url="https://github.com/org/repo")
+
+    def test_url_empty_raises(self):
+        with pytest.raises(Exception):
+            RepoEntry(name="x", url="   ")
+
+
+# ---------------------------------------------------------------------------
+# RepoRegistry.load
+# ---------------------------------------------------------------------------
+
+
+class TestRepoRegistryLoad:
+    def test_load_valid_yaml(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(_write_yaml(tmp_path, VALID_YAML))
+        assert len(reg) == 3
+
+    def test_load_empty_repos_key(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(_write_yaml(tmp_path, "repos: []\n"))
+        assert len(reg) == 0
+
+    def test_load_missing_file_logs_warning(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(tmp_path / "nonexistent.yaml")  # should not raise
+        assert len(reg) == 0
+
+    def test_load_invalid_repos_type_raises(self, tmp_path):
+        reg = RepoRegistry()
+        with pytest.raises(ValueError, match="list"):
+            reg.load(_write_yaml(tmp_path, "repos: not-a-list\n"))
+
+    def test_load_invalid_entry_raises(self, tmp_path):
+        reg = RepoRegistry()
+        with pytest.raises(ValueError, match="entry"):
+            reg.load(_write_yaml(tmp_path, "repos:\n  - not-a-dict\n"))
+
+    def test_load_missing_required_url_raises(self, tmp_path):
+        reg = RepoRegistry()
+        with pytest.raises(ValueError):
+            reg.load(_write_yaml(tmp_path, "repos:\n  - name: x\n"))
+
+    def test_optional_description(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(_write_yaml(tmp_path, VALID_YAML))
+        entry = reg.resolve("no-desc")
+        assert entry.description == ""
+
+    def test_default_branch_custom(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(_write_yaml(tmp_path, VALID_YAML))
+        entry = reg.resolve("infra-scripts")
+        assert entry.default_branch == "develop"
+
+
+# ---------------------------------------------------------------------------
+# RepoRegistry.resolve
+# ---------------------------------------------------------------------------
+
+
+class TestRepoRegistryResolve:
+    def setup_method(self, _):
+        self.reg = RepoRegistry()
+
+    def _load(self, tmp_path):
+        self.reg.load(_write_yaml(tmp_path, VALID_YAML))
+
+    def test_resolve_by_name(self, tmp_path):
+        self._load(tmp_path)
+        e = self.reg.resolve("my-api")
+        assert e.name == "my-api"
+
+    def test_resolve_by_name_case_insensitive(self, tmp_path):
+        self._load(tmp_path)
+        e = self.reg.resolve("MY-API")
+        assert e.name == "my-api"
+
+    def test_resolve_by_full_url(self, tmp_path):
+        self._load(tmp_path)
+        e = self.reg.resolve("https://github.com/org/my-api")
+        assert e.name == "my-api"
+
+    def test_resolve_by_owner_name(self, tmp_path):
+        self._load(tmp_path)
+        e = self.reg.resolve("org/my-api")
+        assert e.name == "my-api"
+
+    def test_resolve_by_canonical_key(self, tmp_path):
+        self._load(tmp_path)
+        e = self.reg.resolve("github.com/org/my-api")
+        assert e.name == "my-api"
+
+    def test_resolve_gitlab_self_hosted(self, tmp_path):
+        self._load(tmp_path)
+        e = self.reg.resolve("infra-scripts")
+        assert "gitlab.internal" in e.url
+
+    def test_resolve_unknown_raises_value_error(self, tmp_path):
+        self._load(tmp_path)
+        with pytest.raises(ValueError, match="not in the registry"):
+            self.reg.resolve("unknown-repo")
+
+    def test_resolve_empty_string_raises(self, tmp_path):
+        self._load(tmp_path)
+        with pytest.raises(ValueError):
+            self.reg.resolve("")
+
+
+# ---------------------------------------------------------------------------
+# RepoRegistry.is_allowed
+# ---------------------------------------------------------------------------
+
+
+class TestRepoRegistryIsAllowed:
+    def setup_method(self, _):
+        self.reg = RepoRegistry()
+
+    def _load(self, tmp_path):
+        self.reg.load(_write_yaml(tmp_path, VALID_YAML))
+
+    def test_allowed_name(self, tmp_path):
+        self._load(tmp_path)
+        assert self.reg.is_allowed("my-api")
+
+    def test_allowed_url(self, tmp_path):
+        self._load(tmp_path)
+        assert self.reg.is_allowed("https://github.com/org/my-api")
+
+    def test_allowed_owner_name(self, tmp_path):
+        self._load(tmp_path)
+        assert self.reg.is_allowed("org/my-api")
+
+    def test_not_allowed_unknown(self, tmp_path):
+        self._load(tmp_path)
+        assert not self.reg.is_allowed("unknown")
+
+    def test_not_allowed_empty(self, tmp_path):
+        self._load(tmp_path)
+        assert not self.reg.is_allowed("")
+
+    def test_empty_registry_allows_nothing(self, tmp_path):
+        self.reg.load(_write_yaml(tmp_path, "repos: []\n"))
+        assert not self.reg.is_allowed("anything")
+
+
+# ---------------------------------------------------------------------------
+# RepoRegistry.list_repos
+# ---------------------------------------------------------------------------
+
+
+class TestRepoRegistryListRepos:
+    def test_list_returns_all(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(_write_yaml(tmp_path, VALID_YAML))
+        repos = reg.list_repos()
+        assert len(repos) == 3
+        names = {r.name for r in repos}
+        assert names == {"my-api", "infra-scripts", "no-desc"}
+
+    def test_list_is_copy(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(_write_yaml(tmp_path, VALID_YAML))
+        a = reg.list_repos()
+        b = reg.list_repos()
+        assert a is not b  # different list objects
+
+    def test_list_empty_registry(self, tmp_path):
+        reg = RepoRegistry()
+        reg.load(_write_yaml(tmp_path, "repos: []\n"))
+        assert reg.list_repos() == []
+
+
+# ---------------------------------------------------------------------------
+# get_registry singleton
+# ---------------------------------------------------------------------------
+
+
+class TestGetRegistrySingleton:
+    def test_singleton_returns_same_object(self, tmp_path):
+        yaml_path = _write_yaml(tmp_path, VALID_YAML)
+        r1 = get_registry(yaml_path)
+        r2 = get_registry(yaml_path)
+        # When path is explicitly passed, a fresh instance is returned each time
+        # (path != None bypasses singleton storage).
+        assert r1 is not r2  # both valid but independent
+
+    def test_explicit_path_loads_correctly(self, tmp_path):
+        yaml_path = _write_yaml(tmp_path, VALID_YAML)
+        reg = get_registry(yaml_path)
+        assert len(reg) == 3
+
+    def test_reload_flag_reloads(self, tmp_path):
+        yaml_path = _write_yaml(tmp_path, VALID_YAML)
+        r1 = get_registry(yaml_path)
+        r2 = get_registry(yaml_path, reload=True)
+        assert len(r1) == len(r2)
+
+    def test_registry_is_always_truthy(self, tmp_path):
+        yaml_path = _write_yaml(tmp_path, "repos: []\n")
+        reg = get_registry(yaml_path)
+        assert bool(reg) is True  # even when empty
+
+
+# ---------------------------------------------------------------------------
+# Integration: registry guard in context_loader_node
+# ---------------------------------------------------------------------------
+
+
+class TestContextLoaderRegistryGuard:
+    """Verify context_loader_node rejects repos not in registry."""
+
+    def test_unknown_repo_stops_workflow(self, tmp_path):
+        from unittest.mock import patch
+
+        from app.core.nodes import context_loader_node
+        from app.core.state import GraphState, WorkflowPhase
+
+        yaml_path = _write_yaml(tmp_path, VALID_YAML)
+
+        state = GraphState(
+            user_request="add feature",
+            repo_ref="not-in-registry",
+        )
+
+        with (
+            patch("app.core.config.get_settings") as mock_settings,
+            patch("infra.registry.get_registry", return_value=get_registry(yaml_path)),
+        ):
+            mock_settings.return_value.target_repo_path = ""
+            mock_settings.return_value.daedalus_workspace_dir = str(tmp_path / "ws")
+            mock_settings.return_value.repos_yaml_path = ""
+            result = context_loader_node(state)
+
+        assert result.get("phase") == WorkflowPhase.STOPPED
+        assert result.get("stop_reason") == "context_repo_not_in_registry"
+
+    def test_known_repo_passes_guard(self, tmp_path):
+        """Registry guard passes; workspace resolve fails (expected in unit test)."""
+        from unittest.mock import patch, MagicMock
+
+        from app.core.nodes import context_loader_node
+        from app.core.state import GraphState, WorkflowPhase
+
+        yaml_path = _write_yaml(tmp_path, VALID_YAML)
+
+        state = GraphState(
+            user_request="add feature",
+            repo_ref="my-api",
+        )
+
+        ws_mock = MagicMock()
+        ws_mock.resolve.side_effect = Exception("no network in tests")
+
+        with (
+            patch("app.core.config.get_settings") as mock_settings,
+            patch("infra.registry.get_registry", return_value=get_registry(yaml_path)),
+            patch("infra.workspace.WorkspaceManager", return_value=ws_mock),
+        ):
+            mock_settings.return_value.target_repo_path = ""
+            mock_settings.return_value.daedalus_workspace_dir = str(tmp_path / "ws")
+            mock_settings.return_value.repos_yaml_path = ""
+            result = context_loader_node(state)
+
+        # Should not be rejected by registry — workspace error instead
+        assert result.get("stop_reason") != "context_repo_not_in_registry"
+
+    def test_empty_registry_skips_guard(self, tmp_path):
+        """When registry is empty, the guard is bypassed (permissive default)."""
+        from unittest.mock import patch, MagicMock
+
+        from app.core.nodes import context_loader_node
+        from app.core.state import GraphState
+
+        empty_yaml = _write_yaml(tmp_path, "repos: []\n")
+
+        state = GraphState(
+            user_request="add feature",
+            repo_ref="any-repo",
+        )
+
+        ws_mock = MagicMock()
+        ws_mock.resolve.side_effect = Exception("no network")
+
+        with (
+            patch("app.core.config.get_settings") as mock_settings,
+            patch("infra.registry.get_registry", return_value=get_registry(empty_yaml)),
+            patch("infra.workspace.WorkspaceManager", return_value=ws_mock),
+        ):
+            mock_settings.return_value.target_repo_path = ""
+            mock_settings.return_value.daedalus_workspace_dir = str(tmp_path / "ws")
+            mock_settings.return_value.repos_yaml_path = ""
+            result = context_loader_node(state)
+
+        assert result.get("stop_reason") != "context_repo_not_in_registry"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _extract_repo_ref in router
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRepoRef:
+    def _call(self, text: str) -> str:
+        from app.core.nodes import _extract_repo_ref
+        return _extract_repo_ref(text)
+
+    def test_full_https_url(self):
+        assert self._call("fix issue #42 in https://github.com/org/my-api") == "https://github.com/org/my-api"
+
+    def test_no_scheme_github(self):
+        ref = self._call("add feature to github.com/org/my-api please")
+        assert ref == "github.com/org/my-api"
+
+    def test_no_scheme_gitlab(self):
+        ref = self._call("check gitlab.internal/team/proj issue 7")
+        assert ref == "gitlab.internal/team/proj"
+
+    def test_keyword_in_alias(self):
+        ref = self._call("fix issue #42 in my-api")
+        assert ref == "my-api"
+
+    def test_keyword_in_owner_name(self):
+        ref = self._call("add feature in org/repo")
+        assert ref == "org/repo"
+
+    def test_keyword_for(self):
+        ref = self._call("create endpoint for infra-scripts")
+        assert ref == "infra-scripts"
+
+    def test_keyword_repo(self):
+        ref = self._call("analyse repo my-service")
+        assert ref == "my-service"
+
+    def test_no_match_returns_empty(self):
+        assert self._call("show me the status") == ""
+        assert self._call("") == ""


### PR DESCRIPTION
Add repos.yaml registry that defines which repositories Daedalus is permitted to clone and modify.

## New files
- infra/registry.py   — RepoEntry model, RepoRegistry class, get_registry()
- repos.yaml          — example registry file at project root
- tests/test_registry.py — 53 tests covering all operations

## Changes
- infra/__init__.py   — exports RepoEntry, RepoRegistry, get_registry
- app/core/nodes.py   — _extract_repo_ref() helper; router populates
                        GraphState.repo_ref; registry guard in
                        context_loader_node (stops unknown repos)
- app/core/config.py  — REPOS_YAML_PATH config key added
- app/web/server.py   — /api/status includes registered_repos list
- app/telegram/bot.py — /status command lists registered repos
- README.md           — Repo Registry section + config table updated
- CHANGELOG.md        — v2.2.0 entry

## Behaviour
- Task targeting unknown repo → stopped with stop_reason=context_repo_not_in_registry
- Empty registry (repos: []) → guard bypassed (permissive default)
- Repo ref extracted from: full URL, no-scheme URL, owner/name, keyword alias

Closes #46