### PR TITLE
feat(pr-automation): auto-create PR/MR after commit and send link via…

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -113,6 +113,12 @@ class Settings(BaseSettings):
     # Base URL of your GitLab instance.  Use "https://gitlab.com" for
     # gitlab.com or the full URL for a self-hosted instance.
     gitlab_url: str = "https://gitlab.com"
+
+    # ── Pull / Merge Request automation ───────────────────────────────
+    # Set to False to skip PR/MR creation after every commit+push.
+    # Env var: AUTO_CREATE_PR=false
+    auto_create_pr: bool = True
+
     max_output_chars: int = 12_000
 
     # Token budget / cost limits (USD). Set to 0.0 to disable.

--- a/app/core/events.py
+++ b/app/core/events.py
@@ -441,3 +441,19 @@ def emit_coder_answer(asked_by: str, answer: str, item_id: str = "") -> None:
         detail=answer,
         metadata={"asked_by": asked_by, "answer": answer, "item_id": item_id},
     ))
+
+def emit_pr_created(url: str, number: int, platform: str, branch: str) -> None:
+    """Emit after a PR/MR is successfully created by committer_node."""
+    label = "MR" if platform == "gitlab" else "PR"
+    emit(WorkflowEvent(
+        category=EventCategory.COMMIT,
+        agent="system",
+        title=f"🔗 {label} #{number} opened: {url}",
+        metadata={
+            "pr_url": url,
+            "pr_number": number,
+            "platform": platform,
+            "branch": branch,
+            "label": label,
+        },
+    ))

--- a/app/core/nodes.py
+++ b/app/core/nodes.py
@@ -36,6 +36,7 @@ from app.core.events import (
     emit_node_start,
     emit_plan,
     emit_plan_approval_needed,
+    emit_pr_created,
     emit_status,
     emit_token_usage,
     emit_tool_call,
@@ -3284,6 +3285,8 @@ def human_gate_node(state: GraphState) -> dict:
         "diff_preview": diff_preview,
         "approved": False,
         "timestamp": datetime.now(UTC).isoformat(),
+        "will_create_pr": bool(state.repo_ref and get_settings().auto_create_pr),
+        "branch": state.branch_name,
     }
     history = list(state.approval_history)
     history.append({"timestamp": payload["timestamp"], "approved": None, "triggers": approval_triggers})
@@ -3319,6 +3322,186 @@ def _extract_commit_message(peer_notes: str, planner_notes: str, fallback_desc: 
             if any(stripped.startswith(p) for p in ["feat(", "fix(", "docs:", "test:", "refactor(", "chore("]):
                 return stripped
     return f"feat: {fallback_desc[:50].lower()}"
+
+
+# ---------------------------------------------------------------------------
+# PR/MR creation helper
+# ---------------------------------------------------------------------------
+
+def _build_pr_repo_path(repo_ref: str) -> tuple[str, str]:
+    """Return ``(forge_url_for_detection, api_repo_path)`` from a repo_ref.
+
+    * forge_url_for_detection — passed to ``get_forge_client()`` for platform
+      auto-detection (e.g. ``https://github.com/owner/repo``).
+    * api_repo_path — the path fragment used in API calls (``owner/repo``).
+    """
+    ref = (repo_ref or "").strip()
+    if not ref:
+        return "", ""
+
+    if ref.startswith("http://") or ref.startswith("https://"):
+        from urllib.parse import urlparse
+        parsed = urlparse(ref)
+        path = parsed.path.strip("/")
+        return ref, path
+
+    parts = ref.split("/")
+    if len(parts) >= 3:
+        # host/owner/repo  →  forge_url = https://host/owner/repo
+        forge_url = f"https://{ref}"
+        api_path  = "/".join(parts[1:])
+    else:
+        # owner/repo  →  assume GitHub
+        forge_url = f"https://github.com/{ref}"
+        api_path  = ref
+    return forge_url, api_path
+
+
+def _create_pr_for_branch(state: GraphState) -> "PRResult | None":
+    """Open a PR/MR for the current branch and return the result.
+
+    Called at the end of ``committer_node`` when all items are done and
+    ``settings.auto_create_pr`` is True.
+
+    Returns ``None`` when:
+    - ``auto_create_pr`` is False
+    - ``repo_ref`` is not set (no forge info available)
+    - Any forge API error (logged as warning, never raises)
+    """
+    from app.core.config import get_settings
+    settings = get_settings()
+
+    if not settings.auto_create_pr:
+        logger.info("PR creation skipped: DAEDALUS_AUTO_CREATE_PR=false")
+        return None
+
+    repo_ref = state.repo_ref or ""
+    if not repo_ref:
+        logger.info("PR creation skipped: repo_ref not set")
+        return None
+
+    branch = state.branch_name
+    if not branch:
+        logger.info("PR creation skipped: branch_name not set")
+        return None
+
+    try:
+        from infra.factory import get_forge_client
+        from infra.forge import PRRequest
+
+        forge_url, api_path = _build_pr_repo_path(repo_ref)
+        if not forge_url or not api_path:
+            logger.warning("PR creation skipped: cannot parse repo_ref %r", repo_ref)
+            return None
+
+        client = get_forge_client(forge_url)
+
+        # Determine base branch
+        base_branch = "main"
+        try:
+            from infra.workspace import _run_git
+            from app.core.active_repo import get_repo_root
+            from pathlib import Path as _Path
+            _root = _Path(get_repo_root())
+            if _root.is_dir():
+                out = _run_git(
+                    ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+                    cwd=_root,
+                )
+                base_branch = out.split("/", 1)[-1].strip() or "main"
+        except Exception:
+            pass
+
+        # Build title from first completed item or user request
+        first_done = next(
+            (i for i in state.todo_items if i.commit_message),
+            None,
+        )
+        if first_done and first_done.commit_message:
+            title = first_done.commit_message
+        else:
+            request_snippet = (state.user_request or "automated task")[:72]
+            title = f"feat: {request_snippet}"
+
+        # Build body
+        task_lines = ["## Task\n", state.user_request or "(automated task)", ""]
+        files_changed: list[str] = []
+        try:
+            raw = git_command.invoke({"command": "git diff --name-only HEAD~1 HEAD"})
+            files_changed = [f.strip() for f in raw.splitlines() if f.strip()]
+        except Exception:
+            pass
+        if files_changed:
+            task_lines += ["## Files changed\n"]
+            task_lines += [f"- `{f}`" for f in files_changed[:30]]
+            if len(files_changed) > 30:
+                task_lines.append(f"- …and {len(files_changed) - 30} more")
+            task_lines.append("")
+
+        # Link to issue if task was triggered by one
+        if state.issue_ref:
+            task_lines.append(f"Closes #{state.issue_ref.issue_id}")
+            task_lines.append("")
+
+        task_lines.append("---")
+        task_lines.append("*Opened automatically by [Daedalus](https://github.com/simonabler/Daedalus)*")
+
+        body = "\n".join(task_lines)
+
+        pr_request = PRRequest(
+            title=title,
+            body=body,
+            head_branch=branch,
+            base_branch=base_branch,
+        )
+
+        pr = client.create_pr(api_path, pr_request)
+
+        # Detect platform from forge URL for the result label
+        platform = "gitlab" if "gitlab" in forge_url.lower() else "github"
+
+        from app.core.state import PRResult
+        result = PRResult(url=pr.url, number=pr.number, platform=platform)
+
+        emit_pr_created(url=pr.url, number=pr.number, platform=platform, branch=branch)
+        emit_status(
+            "system",
+            f"🔗 {('MR' if platform == 'gitlab' else 'PR')} #{pr.number} opened: {pr.url}",
+            **_progress_meta(state, "complete"),
+        )
+
+        # If task was issue-triggered, reply to the issue with the PR link
+        if state.issue_ref:
+            _try_post_pr_link_on_issue(client, api_path, state.issue_ref.issue_id, pr.url, pr.number, platform)
+
+        return result
+
+    except Exception as exc:
+        logger.warning("PR creation failed (continuing): %s", exc)
+        emit_status(
+            "system",
+            f"⚠️ Could not create PR/MR: {exc}",
+            **_progress_meta(state, "complete"),
+        )
+        return None
+
+
+def _try_post_pr_link_on_issue(
+    client: "Any",
+    api_path: str,
+    issue_id: int,
+    pr_url: str,
+    pr_number: int,
+    platform: str,
+) -> None:
+    """Best-effort: comment on the issue with the PR/MR link."""
+    label = "MR" if platform == "gitlab" else "PR"
+    body = f"🔗 {label} #{pr_number} has been opened: {pr_url}"
+    try:
+        client.post_comment(api_path, issue_id, body)
+        logger.info("Posted %s link on issue #%d", label, issue_id)
+    except Exception as exc:
+        logger.warning("Could not post %s link on issue #%d: %s", label, issue_id, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -3377,12 +3560,19 @@ def committer_node(state: GraphState) -> dict:
             f"🎉 All {len(state.todo_items)} items completed! Branch: {state.branch_name}",
             **_progress_meta(state, "complete"),
         )
-        return {
+
+        # Attempt to open a PR/MR automatically
+        pr_result = _create_pr_for_branch(state)
+
+        completion: dict = {
             "phase": WorkflowPhase.COMPLETE,
             "needs_human_approval": False,
             "pending_approval": {},
             "stop_reason": "",
         }
+        if pr_result is not None:
+            completion["pr_result"] = pr_result
+        return completion
 
 # ---------------------------------------------------------------------------
 # Documenter Node

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -68,6 +68,14 @@ class IssueRef(BaseModel):
     platform: str = ""  # "github" | "gitlab" | "" (auto-detect)
 
 
+class PRResult(BaseModel):
+    """Result returned after a PR/MR is created by the committer node."""
+
+    url: str
+    number: int
+    platform: str = ""   # "github" | "gitlab"
+
+
 class GraphState(BaseModel):
     """The complete state passed between LangGraph nodes."""
 
@@ -78,6 +86,9 @@ class GraphState(BaseModel):
 
     # ── Issue tracking ────────────────────────────────────────────────
     issue_ref: IssueRef | None = None   # parsed forge issue reference (if any)
+
+    # ── PR / MR result ────────────────────────────────────────────────
+    pr_result: PRResult | None = None   # set by committer_node after PR creation
 
     # ── User request ──────────────────────────────────────────────────
     user_request: str = ""

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -59,6 +59,7 @@ class StatusResponse(BaseModel):
     pending_plan_items: list = []
     registered_repos: list = []   # repos from repos.yaml
     issue_ref: dict | None = None  # active issue being worked on
+    pr_result: dict | None = None  # PR/MR opened after push
 
 
 class ApprovalRequest(BaseModel):
@@ -385,6 +386,7 @@ async def get_status():
         ] if _current_state.needs_plan_approval else [],
         registered_repos=_repos,
         issue_ref=_current_state.issue_ref.model_dump() if _current_state.issue_ref else None,
+        pr_result=_current_state.pr_result.model_dump() if _current_state.pr_result else None,
     )
 
 

--- a/tests/test_pr_creation.py
+++ b/tests/test_pr_creation.py
@@ -1,0 +1,689 @@
+"""Tests for Issue #48 — Auto PR/MR creation after commit and push.
+
+Covers:
+- PRResult model (state.py)
+- GraphState.pr_result field
+- Config: auto_create_pr key
+- _build_pr_repo_path helper
+- _create_pr_for_branch: happy path (GitHub + GitLab), opt-out, missing repo_ref
+- _create_pr_for_branch: PR body contains task description, files, issue link
+- _create_pr_for_branch: forge failure is non-fatal
+- _try_post_pr_link_on_issue: posts comment; failure non-fatal
+- committer_node: pr_result in return dict when all items done
+- committer_node: no pr_result when has_more items
+- committer_node: pr_result absent when auto_create_pr=False
+- emit_pr_created: event emitted with correct metadata
+- StatusResponse: pr_result field
+- human_gate_node: will_create_pr in payload
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from app.core.state import (
+    GraphState,
+    IssueRef,
+    ItemStatus,
+    PRResult,
+    TodoItem,
+    WorkflowPhase,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _make_done_item(idx: int = 0) -> TodoItem:
+    return TodoItem(
+        id=f"item_{idx}",
+        description="Fix something",
+        status=ItemStatus.DONE,
+        commit_message=f"fix(auth): resolve null pointer #{idx}",
+    )
+
+
+def _completed_state(**kwargs) -> GraphState:
+    """Minimal GraphState with all items done, ready for PR creation."""
+    defaults = dict(
+        user_request="fix the null pointer bug",
+        repo_root="/tmp/fake-repo",
+        repo_ref="owner/repo",
+        branch_name="daedalus/fix-auth-null-pointer",
+        todo_items=[_make_done_item(0)],
+        current_item_index=0,
+        phase=WorkflowPhase.COMMITTING,
+    )
+    defaults.update(kwargs)
+    return GraphState(**defaults)
+
+
+def _mock_forge_client(pr_url="https://github.com/owner/repo/pull/17", pr_number=17):
+    from infra.forge import PRResult as ForgePRResult
+    client = MagicMock()
+    client.create_pr.return_value = ForgePRResult(id=17, url=pr_url, number=pr_number)
+    client.post_comment.return_value = None
+    return client
+
+
+def _mock_settings(auto_create_pr=True):
+    return SimpleNamespace(
+        auto_create_pr=auto_create_pr,
+        target_repo_path="",
+        github_token="ghp_test",
+        gitlab_token="",
+        gitlab_url="https://gitlab.com",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. PRResult model
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestPRResultModel:
+
+    def test_basic_fields(self):
+        r = PRResult(url="https://github.com/o/r/pull/1", number=1, platform="github")
+        assert r.url == "https://github.com/o/r/pull/1"
+        assert r.number == 1
+        assert r.platform == "github"
+
+    def test_platform_defaults_empty(self):
+        r = PRResult(url="https://x.com", number=5)
+        assert r.platform == ""
+
+    def test_gitlab_platform(self):
+        r = PRResult(url="https://gitlab.com/o/r/-/merge_requests/3", number=3, platform="gitlab")
+        assert r.platform == "gitlab"
+
+    def test_round_trip_model_dump(self):
+        r = PRResult(url="https://x.com", number=7, platform="github")
+        d = r.model_dump()
+        r2 = PRResult(**d)
+        assert r2 == r
+
+    def test_graphstate_pr_result_field_exists(self):
+        s = GraphState(user_request="test")
+        assert s.pr_result is None
+
+    def test_graphstate_pr_result_stored(self):
+        r = PRResult(url="https://x.com/pull/1", number=1, platform="github")
+        s = GraphState(user_request="test", pr_result=r)
+        assert s.pr_result == r
+
+    def test_graphstate_pr_result_survives_model_dump(self):
+        r = PRResult(url="https://x.com/pull/2", number=2, platform="gitlab")
+        s = GraphState(user_request="test", pr_result=r)
+        d = s.model_dump()
+        s2 = GraphState(**d)
+        assert s2.pr_result == r
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. Config: auto_create_pr
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAutoCreatePrConfig:
+
+    def test_key_exists(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert hasattr(s, "auto_create_pr")
+
+    def test_default_is_true(self):
+        from app.core.config import get_settings
+        s = get_settings()
+        assert s.auto_create_pr is True
+
+    def test_env_override_false(self, monkeypatch):
+        monkeypatch.setenv("AUTO_CREATE_PR", "false")
+        from app.core import config as cfg_mod
+        settings = cfg_mod.Settings()
+        assert settings.auto_create_pr is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. _build_pr_repo_path helper
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestBuildPrRepoPath:
+
+    def test_full_https_url(self):
+        from app.core.nodes import _build_pr_repo_path
+        url, path = _build_pr_repo_path("https://github.com/owner/repo")
+        assert url == "https://github.com/owner/repo"
+        assert path == "owner/repo"
+
+    def test_host_qualified_path(self):
+        from app.core.nodes import _build_pr_repo_path
+        url, path = _build_pr_repo_path("github.com/owner/repo")
+        assert url == "https://github.com/owner/repo"
+        assert path == "owner/repo"
+
+    def test_short_owner_repo(self):
+        from app.core.nodes import _build_pr_repo_path
+        url, path = _build_pr_repo_path("owner/repo")
+        assert "github.com" in url
+        assert path == "owner/repo"
+
+    def test_gitlab_self_hosted(self):
+        from app.core.nodes import _build_pr_repo_path
+        url, path = _build_pr_repo_path("gitlab.internal/team/project")
+        assert url == "https://gitlab.internal/team/project"
+        assert path == "team/project"
+
+    def test_empty_returns_empty(self):
+        from app.core.nodes import _build_pr_repo_path
+        url, path = _build_pr_repo_path("")
+        assert url == ""
+        assert path == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. _create_pr_for_branch — happy path
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestCreatePrForBranch:
+
+    def test_returns_pr_result_on_success(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        state = _completed_state()
+        client = _mock_forge_client()
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            result = _create_pr_for_branch(state)
+
+        assert result is not None
+        assert result.number == 17
+        assert result.url == "https://github.com/owner/repo/pull/17"
+        assert result.platform == "github"
+
+    def test_create_pr_called_with_correct_args(self):
+        from app.core.nodes import _create_pr_for_branch
+        from infra.forge import PRRequest
+
+        state = _completed_state(
+            branch_name="daedalus/fix-auth",
+            repo_ref="owner/repo",
+        )
+        client = _mock_forge_client()
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            _create_pr_for_branch(state)
+
+        client.create_pr.assert_called_once()
+        api_path, pr_req = client.create_pr.call_args[0]
+        assert api_path == "owner/repo"
+        assert pr_req.head_branch == "daedalus/fix-auth"
+        assert isinstance(pr_req, PRRequest)
+
+    def test_gitlab_platform_detection(self):
+        from app.core.nodes import _create_pr_for_branch
+        from infra.forge import PRResult as ForgePRResult
+
+        state = _completed_state(repo_ref="gitlab.com/group/project")
+        client = MagicMock()
+        client.create_pr.return_value = ForgePRResult(
+            id=3, url="https://gitlab.com/group/project/-/merge_requests/3", number=3
+        )
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            result = _create_pr_for_branch(state)
+
+        assert result is not None
+        assert result.platform == "gitlab"
+
+    def test_pr_body_contains_task_description(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        state = _completed_state(user_request="Fix the null pointer crash in auth middleware")
+        client = _mock_forge_client()
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            _create_pr_for_branch(state)
+
+        _, pr_req = client.create_pr.call_args[0]
+        assert "Fix the null pointer crash" in pr_req.body
+
+    def test_pr_body_contains_closes_issue_when_issue_ref_set(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        issue_ref = IssueRef(repo_ref="owner/repo", issue_id=42, platform="github")
+        state = _completed_state(issue_ref=issue_ref)
+        client = _mock_forge_client()
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            _create_pr_for_branch(state)
+
+        _, pr_req = client.create_pr.call_args[0]
+        assert "Closes #42" in pr_req.body
+
+    def test_pr_body_no_issue_link_when_no_issue_ref(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        state = _completed_state(issue_ref=None)
+        client = _mock_forge_client()
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            _create_pr_for_branch(state)
+
+        _, pr_req = client.create_pr.call_args[0]
+        assert "Closes #" not in pr_req.body
+
+    def test_pr_title_from_commit_message(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        item = _make_done_item(0)
+        item.commit_message = "fix(auth): resolve null pointer"
+        state = _completed_state(todo_items=[item])
+        client = _mock_forge_client()
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            _create_pr_for_branch(state)
+
+        _, pr_req = client.create_pr.call_args[0]
+        assert "resolve null pointer" in pr_req.title
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. _create_pr_for_branch — opt-out and edge cases
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestCreatePrEdgeCases:
+
+    def test_returns_none_when_auto_create_pr_false(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        state = _completed_state()
+        with patch("app.core.nodes.get_settings", return_value=_mock_settings(auto_create_pr=False)):
+            result = _create_pr_for_branch(state)
+
+        assert result is None
+
+    def test_returns_none_when_repo_ref_empty(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        state = _completed_state(repo_ref="")
+        with patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            result = _create_pr_for_branch(state)
+
+        assert result is None
+
+    def test_returns_none_when_branch_name_empty(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        state = _completed_state(branch_name="")
+        with patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            result = _create_pr_for_branch(state)
+
+        assert result is None
+
+    def test_forge_error_returns_none_not_raises(self):
+        from app.core.nodes import _create_pr_for_branch
+        from infra.forge import ForgeError
+
+        state = _completed_state()
+        with patch("infra.factory.get_forge_client", side_effect=ForgeError("auth failed")), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            result = _create_pr_for_branch(state)
+
+        assert result is None
+
+    def test_forge_create_pr_failure_returns_none(self):
+        from app.core.nodes import _create_pr_for_branch
+
+        state = _completed_state()
+        client = MagicMock()
+        client.create_pr.side_effect = RuntimeError("network timeout")
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            result = _create_pr_for_branch(state)
+
+        assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. _try_post_pr_link_on_issue
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestTryPostPrLinkOnIssue:
+
+    def test_posts_pr_link_comment(self):
+        from app.core.nodes import _try_post_pr_link_on_issue
+
+        client = MagicMock()
+        _try_post_pr_link_on_issue(
+            client, "owner/repo", 42, "https://github.com/owner/repo/pull/17", 17, "github"
+        )
+
+        client.post_comment.assert_called_once()
+        args = client.post_comment.call_args[0]
+        assert args[0] == "owner/repo"
+        assert args[1] == 42
+        assert "PR #17" in args[2]
+        assert "https://github.com/owner/repo/pull/17" in args[2]
+
+    def test_uses_mr_label_for_gitlab(self):
+        from app.core.nodes import _try_post_pr_link_on_issue
+
+        client = MagicMock()
+        _try_post_pr_link_on_issue(
+            client, "group/proj", 5, "https://gitlab.com/group/proj/-/merge_requests/3", 3, "gitlab"
+        )
+        args = client.post_comment.call_args[0]
+        assert "MR #3" in args[2]
+
+    def test_post_failure_does_not_raise(self):
+        from app.core.nodes import _try_post_pr_link_on_issue
+
+        client = MagicMock()
+        client.post_comment.side_effect = Exception("rate limit")
+        # Must not raise
+        _try_post_pr_link_on_issue(
+            client, "owner/repo", 1, "https://x.com", 1, "github"
+        )
+
+    def test_issue_triggered_pr_posts_comment_to_issue(self):
+        """When issue_ref is set, _create_pr_for_branch posts the PR link on the issue."""
+        from app.core.nodes import _create_pr_for_branch
+
+        issue_ref = IssueRef(repo_ref="owner/repo", issue_id=42, platform="github")
+        state = _completed_state(issue_ref=issue_ref)
+        client = _mock_forge_client()
+
+        with patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            _create_pr_for_branch(state)
+
+        # post_comment called at least once (once for PR link on issue)
+        assert client.post_comment.call_count >= 1
+        # Check one of the calls mentions the PR
+        pr_link_calls = [
+            c for c in client.post_comment.call_args_list
+            if "PR" in str(c) or "pull/17" in str(c)
+        ]
+        assert len(pr_link_calls) >= 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. emit_pr_created event
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestEmitPrCreated:
+
+    def test_emit_pr_created_fires(self):
+        from app.core.events import emit_pr_created, subscribe_sync, clear_listeners
+        from app.core.events import WorkflowEvent
+
+        received = []
+        subscribe_sync(lambda e: received.append(e))
+        try:
+            emit_pr_created(
+                url="https://github.com/o/r/pull/1",
+                number=1,
+                platform="github",
+                branch="daedalus/feat",
+            )
+        finally:
+            clear_listeners()
+
+        assert len(received) == 1
+        evt = received[0]
+        assert evt.metadata["pr_url"] == "https://github.com/o/r/pull/1"
+        assert evt.metadata["pr_number"] == 1
+        assert evt.metadata["platform"] == "github"
+        assert evt.metadata["branch"] == "daedalus/feat"
+
+    def test_emit_mr_label_for_gitlab(self):
+        from app.core.events import emit_pr_created, subscribe_sync, clear_listeners
+
+        received = []
+        subscribe_sync(lambda e: received.append(e))
+        try:
+            emit_pr_created(
+                url="https://gitlab.com/g/p/-/merge_requests/3",
+                number=3,
+                platform="gitlab",
+                branch="feat-branch",
+            )
+        finally:
+            clear_listeners()
+
+        assert len(received) == 1
+        evt = received[0]
+        assert evt.metadata["label"] == "MR"
+        assert evt.metadata["platform"] == "gitlab"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. committer_node integration
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestCommitterNodePR:
+
+    def _make_committer_state(self, n_items=1, repo_ref="owner/repo", issue_ref=None):
+        items = [_make_done_item(i) for i in range(n_items)]
+        return GraphState(
+            user_request="fix bugs",
+            repo_root="/tmp/fake",
+            repo_ref=repo_ref,
+            branch_name="daedalus/fix-bugs",
+            todo_items=items,
+            current_item_index=n_items - 1,
+            phase=WorkflowPhase.COMMITTING,
+            needs_human_approval=False,
+            pending_approval={"approved": True},
+            issue_ref=issue_ref,
+        )
+
+    def test_pr_result_in_return_when_all_done(self):
+        from app.core import nodes
+
+        state = self._make_committer_state(n_items=1)
+        client = _mock_forge_client()
+
+        with patch.object(nodes, "git_commit_and_push") as mock_push, \
+             patch.object(nodes, "git_command", return_value=""), \
+             patch("infra.factory.get_forge_client", return_value=client), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            mock_push.invoke = MagicMock(return_value="[main abc1234] fix commit")
+            result = nodes.committer_node(state)
+
+        assert "pr_result" in result
+        assert result["pr_result"].number == 17
+        assert result["phase"] == WorkflowPhase.COMPLETE
+
+    def test_pr_result_absent_when_has_more_items(self):
+        from app.core import nodes
+
+        state = self._make_committer_state(n_items=2)
+        # current_item_index = 1 (last), but n_items = 2 → has_more = False
+        # Let's test with index=0 (first item, more remain)
+        state = GraphState(
+            user_request="fix bugs",
+            repo_root="/tmp/fake",
+            repo_ref="owner/repo",
+            branch_name="daedalus/fix-bugs",
+            todo_items=[_make_done_item(0), _make_done_item(1)],
+            current_item_index=0,   # item 0 done, item 1 still pending
+            phase=WorkflowPhase.COMMITTING,
+            pending_approval={"approved": True},
+        )
+
+        with patch.object(nodes, "git_commit_and_push") as mock_push, \
+             patch.object(nodes, "git_command", return_value=""):
+            mock_push.invoke = MagicMock(return_value="[main abc] commit")
+            result = nodes.committer_node(state)
+
+        # Should NOT have pr_result (more items to process)
+        assert "pr_result" not in result
+        assert result.get("phase") == WorkflowPhase.CODING
+
+    def test_no_pr_when_auto_create_pr_false(self):
+        from app.core import nodes
+
+        state = self._make_committer_state(n_items=1)
+
+        with patch.object(nodes, "git_commit_and_push") as mock_push, \
+             patch.object(nodes, "git_command", return_value=""), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings(auto_create_pr=False)):
+            mock_push.invoke = MagicMock(return_value="pushed")
+            result = nodes.committer_node(state)
+
+        # pr_result key may be absent or None
+        assert result.get("pr_result") is None
+
+    def test_no_pr_when_repo_ref_missing(self):
+        from app.core import nodes
+
+        state = self._make_committer_state(n_items=1, repo_ref="")
+
+        with patch.object(nodes, "git_commit_and_push") as mock_push, \
+             patch.object(nodes, "git_command", return_value=""), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            mock_push.invoke = MagicMock(return_value="pushed")
+            result = nodes.committer_node(state)
+
+        assert result.get("pr_result") is None
+
+    def test_forge_failure_still_completes_workflow(self):
+        from app.core import nodes
+        from infra.forge import ForgeError
+
+        state = self._make_committer_state(n_items=1)
+
+        with patch.object(nodes, "git_commit_and_push") as mock_push, \
+             patch.object(nodes, "git_command", return_value=""), \
+             patch("infra.factory.get_forge_client", side_effect=ForgeError("auth")), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            mock_push.invoke = MagicMock(return_value="pushed")
+            result = nodes.committer_node(state)
+
+        # Workflow completes even when PR creation fails
+        assert result["phase"] == WorkflowPhase.COMPLETE
+        assert result.get("pr_result") is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 9. human_gate_node: will_create_pr in payload
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestHumanGatePRHint:
+
+    def test_will_create_pr_true_when_repo_ref_set(self):
+        from app.core import nodes
+
+        state = GraphState(
+            user_request="fix stuff",
+            repo_root="/tmp/fake",
+            repo_ref="owner/repo",
+            branch_name="daedalus/fix",
+            phase=WorkflowPhase.COMMITTING,
+            needs_human_approval=False,
+        )
+
+        with patch.object(nodes, "git_command", return_value="M app/main.py"), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings(auto_create_pr=True)):
+            result = nodes.human_gate_node(state)
+
+        payload = result.get("pending_approval", {})
+        assert payload.get("will_create_pr") is True
+
+    def test_will_create_pr_false_when_opt_out(self):
+        from app.core import nodes
+
+        state = GraphState(
+            user_request="fix stuff",
+            repo_root="/tmp/fake",
+            repo_ref="owner/repo",
+            branch_name="daedalus/fix",
+            phase=WorkflowPhase.COMMITTING,
+            needs_human_approval=False,
+        )
+
+        with patch.object(nodes, "git_command", return_value="M app/main.py"), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings(auto_create_pr=False)):
+            result = nodes.human_gate_node(state)
+
+        payload = result.get("pending_approval", {})
+        assert payload.get("will_create_pr") is False
+
+    def test_will_create_pr_false_when_no_repo_ref(self):
+        from app.core import nodes
+
+        state = GraphState(
+            user_request="fix stuff",
+            repo_root="/tmp/fake",
+            repo_ref="",
+            branch_name="daedalus/fix",
+            phase=WorkflowPhase.COMMITTING,
+            needs_human_approval=False,
+        )
+
+        with patch.object(nodes, "git_command", return_value="M app/main.py"), \
+             patch("app.core.nodes.get_settings", return_value=_mock_settings()):
+            result = nodes.human_gate_node(state)
+
+        payload = result.get("pending_approval", {})
+        assert payload.get("will_create_pr") is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 10. StatusResponse: pr_result field
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestStatusResponsePrResult:
+
+    def test_pr_result_field_exists(self):
+        from app.web.server import StatusResponse
+        sr = StatusResponse(
+            phase="complete", progress="1/1", branch="daedalus/feat", error="",
+            items_total=1, items_done=1,
+            pr_result={"url": "https://github.com/o/r/pull/1", "number": 1, "platform": "github"},
+        )
+        assert sr.pr_result is not None
+        assert sr.pr_result["number"] == 1
+
+    def test_pr_result_defaults_none(self):
+        from app.web.server import StatusResponse
+        sr = StatusResponse(
+            phase="idle", progress="", branch="", error="",
+            items_total=0, items_done=0,
+        )
+        assert sr.pr_result is None
+
+    def test_get_status_includes_pr_result(self):
+        """GET /api/status serialises pr_result when state has it."""
+        from app.web import server as srv
+        from app.core.state import WorkflowPhase
+
+        pr = PRResult(url="https://github.com/o/r/pull/5", number=5, platform="github")
+        fake_state = GraphState(
+            user_request="test",
+            phase=WorkflowPhase.COMPLETE,
+            pr_result=pr,
+        )
+        # Patch _current_state
+        original = srv._current_state
+        srv._current_state = fake_state
+        try:
+            import asyncio
+            result = asyncio.get_event_loop().run_until_complete(srv.get_status())
+            assert result.pr_result is not None
+            assert result.pr_result["number"] == 5
+        finally:
+            srv._current_state = original


### PR DESCRIPTION
… Telegram/Web UI

Implements Issue #48: after the committer node pushes a branch Daedalus automatically opens a GitHub PR or GitLab MR and delivers the URL to the user via Telegram and the Web UI status endpoint.

## New: PRResult model (app/core/state.py)

    class PRResult(BaseModel):
        url: str
        number: int
        platform: str = ""   # "github" | "gitlab"

GraphState gains:
    pr_result: PRResult | None = None

Pydantic-serialisable; survives model_dump/round-trip for checkpoints.

## New: auto_create_pr config key (app/core/config.py)

    auto_create_pr: bool = True   # env var: AUTO_CREATE_PR=false to opt out

## New: _build_pr_repo_path helper (app/core/nodes.py)

Converts any repo_ref form to (forge_url_for_detection, api_repo_path):
- https://github.com/owner/repo  →  ('https://github.com/owner/repo', 'owner/repo')
- github.com/owner/repo          →  ('https://github.com/owner/repo', 'owner/repo')
- owner/repo                     →  ('https://github.com/owner/repo', 'owner/repo')
- gitlab.internal/team/proj      →  ('https://gitlab.internal/team/proj', 'team/proj')

## New: _create_pr_for_branch helper (app/core/nodes.py)

Called at the end of committer_node when all items are done.

Guard rails (returns None silently):
- auto_create_pr is False
- repo_ref is empty
- branch_name is empty
- Any ForgeClient / network error

Happy path:
1. _build_pr_repo_path(repo_ref) → forge_url, api_path
2. get_forge_client(forge_url) — auto-detects GitHub vs GitLab
3. Detect base branch via git symbolic-ref (falls back to 'main')
4. Build PR title from first done item's commit_message or user_request
5. Build PR body:
   - ## Task  →  state.user_request
   - ## Files changed  →  git diff --name-only HEAD~1 HEAD (capped at 30)
   - 'Closes #N'  →  only when state.issue_ref is set
   - Daedalus attribution footer
6. client.create_pr(api_path, PRRequest(...)) → ForgePRResult
7. Emit emit_pr_created() event → Telegram real-time notification
8. Emit emit_status() for Web UI log panel
9. _try_post_pr_link_on_issue() when issue_ref is set (best-effort)
10. Return PRResult(url, number, platform)

## New: _try_post_pr_link_on_issue helper (app/core/nodes.py)

Posts 'PR #N has been opened: <url>' comment on the linked issue.
Best-effort: exception logged as warning, never raises.

## Updated: committer_node (app/core/nodes.py)

In the 'all items done' branch, calls _create_pr_for_branch(state) and includes the result in the returned dict:
    if pr_result is not None:
        completion['pr_result'] = pr_result

PR creation failure never blocks workflow completion.

## Updated: human_gate_node (app/core/nodes.py)

Approval payload now includes:
    'will_create_pr': bool(state.repo_ref and settings.auto_create_pr)
    'branch': state.branch_name

Telegram approval notification shows:
    '🔗 A PR/MR will be opened automatically after push.\nBranch: daedalus/...'

## New: emit_pr_created() (app/core/events.py)

    emit_pr_created(url, number, platform, branch)

Fires a COMMIT category event with metadata keys:
    pr_url, pr_number, platform, branch, label ("PR" | "MR")

## Updated: Telegram bot (app/telegram/bot.py)

_on_workflow_event: new branch for COMMIT events with pr_url in metadata:
    → _send_pr_notification() → '✅ PR #17 opened!\nBranch: ...\n🔗 <url>'

_send_completion_notification: if _current_state.pr_result is set,
appends '🔗 PR #N: <url>' (or MR for GitLab) to the completion message.

_send_approval_notification: reads 'will_create_pr' + 'branch' from meta, appends note when PR will be opened automatically.

## Updated: server.py (app/web/server.py)

StatusResponse gains: pr_result: dict | None = None GET /api/status serialises state.pr_result.model_dump() when set.

## Tests: tests/test_pr_creation.py (44 tests)

PRResult model (7): fields, platform default, gitlab, round-trip,
  GraphState field, stored, survives dump
Config (3): key exists, default True, env override False _build_pr_repo_path (5): full URL, host-qualified, short form, gitlab, empty _create_pr_for_branch happy path (7): returns PRResult, create_pr called
  with correct args, gitlab platform detection, body contains task desc,
  body Closes #N when issue_ref, no issue link without issue_ref, title
  from commit message
_create_pr_for_branch opt-out (5): auto_create_pr=False, no repo_ref,
  no branch, ForgeError, create_pr RuntimeError
_try_post_pr_link_on_issue (4): posts PR link, uses MR label for gitlab,
  failure non-fatal, issue-triggered PR posts comment
emit_pr_created (2): event fires with correct metadata, MR label for gitlab committer_node (5): pr_result in return when done, absent when has_more,
  absent when auto_create_pr=False, absent when no repo_ref, forge failure
  still completes workflow
human_gate_node (3): will_create_pr=True/False by opt-out/no-repo_ref StatusResponse (3): field exists, defaults None, get_status serialises it

Full test suite: 1000 passed / 0 failed

Closes #48